### PR TITLE
Unify all data paths under ~/.openexp/

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,10 +10,10 @@ OPENEXP_COLLECTION=openexp_memories
 # OPENEXP_DATA_DIR=~/.openexp/data
 
 # Observations directory (where Claude Code hooks write observations)
-# OPENEXP_OBSERVATIONS_DIR=~/.claude-memory/observations
+# OPENEXP_OBSERVATIONS_DIR=~/.openexp/observations
 
 # Sessions directory (where Claude Code writes session summaries)
-# OPENEXP_SESSIONS_DIR=~/.claude-memory/sessions
+# OPENEXP_SESSIONS_DIR=~/.openexp/sessions
 
 # Anthropic API key (optional — only needed for LLM-based enrichment)
 # Without this, memories are stored with basic metadata (still works great!)

--- a/README.md
+++ b/README.md
@@ -180,8 +180,8 @@ All settings via environment variables (`.env`):
 | `QDRANT_PORT` | `6333` | Qdrant server port |
 | `OPENEXP_COLLECTION` | `openexp_memories` | Qdrant collection name |
 | `OPENEXP_DATA_DIR` | `~/.openexp/data` | Q-cache, predictions, retrieval logs |
-| `OPENEXP_OBSERVATIONS_DIR` | `~/.claude-memory/observations` | Where hooks write observations |
-| `OPENEXP_SESSIONS_DIR` | `~/.claude-memory/sessions` | Session summary files |
+| `OPENEXP_OBSERVATIONS_DIR` | `~/.openexp/observations` | Where hooks write observations |
+| `OPENEXP_SESSIONS_DIR` | `~/.openexp/sessions` | Session summary files |
 | `OPENEXP_EMBEDDING_MODEL` | `BAAI/bge-small-en-v1.5` | Embedding model (local, free) |
 | `OPENEXP_EMBEDDING_DIM` | `384` | Embedding dimensions |
 | `OPENEXP_INGEST_BATCH_SIZE` | `50` | Batch size for ingestion |
@@ -242,7 +242,7 @@ Only `active` and `confirmed` memories are returned in searches. Status weights 
 PostToolUse hook                                  SessionStart hook
       │                                                 ↑
       ↓                                                 │
-~/.claude-memory/observations/*.jsonl          Qdrant search (top 10)
+~/.openexp/observations/*.jsonl                Qdrant search (top 10)
       │                                          + Q-value reranking
       ↓                                                 ↑
 openexp ingest ──→ FastEmbed ──→ Qdrant ─────────────────┘

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,7 +25,7 @@
        ▼                 ▼                      ▼
 ┌──────────────────────────────┐    ┌────────────────────┐
 │        OpenExp Core          │    │  Observations Dir  │
-│                              │    │  ~/.claude-memory/ │
+│                              │    │  ~/.openexp/       │
 │  ┌──────────────────────┐   │    │  observations/     │
 │  │   direct_search.py   │   │    └─────────┬──────────┘
 │  │   FastEmbed + Qdrant │   │              │
@@ -98,6 +98,6 @@ Shell scripts registered with Claude Code:
 | Q-value deltas | `~/.openexp/data/deltas/` | Per-session delta files (merged on start) |
 | Predictions | `~/.openexp/data/predictions.jsonl` | Agent predictions for outcome tracking |
 | Retrieval log | `~/.openexp/data/session_retrievals.jsonl` | Which memories were recalled when |
-| Raw observations | `~/.claude-memory/observations/` | JSONL files per day |
-| Session summaries | `~/.claude-memory/sessions/` | Markdown files per session |
+| Raw observations | `~/.openexp/observations/` | JSONL files per day |
+| Session summaries | `~/.openexp/sessions/` | Markdown files per session |
 | Ingest watermark | `~/.openexp/data/ingest_watermark.json` | Processed observation IDs |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,8 +19,8 @@ OpenExp uses Qdrant as its vector database. The setup script starts it via Docke
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `OPENEXP_DATA_DIR` | `~/.openexp/data` | Q-cache, predictions, retrieval logs |
-| `OPENEXP_OBSERVATIONS_DIR` | `~/.claude-memory/observations` | Where hooks write observations |
-| `OPENEXP_SESSIONS_DIR` | `~/.claude-memory/sessions` | Session summary markdown files |
+| `OPENEXP_OBSERVATIONS_DIR` | `~/.openexp/observations` | Where hooks write observations |
+| `OPENEXP_SESSIONS_DIR` | `~/.openexp/sessions` | Session summary markdown files |
 
 ### Embedding Model
 | Variable | Default | Description |

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -26,7 +26,7 @@ Every time Claude Code uses a tool (writes a file, runs a command, edits code), 
 }
 ```
 
-These observations are written to `~/.claude-memory/observations/` as JSONL files.
+These observations are written to `~/.openexp/observations/` as JSONL files.
 
 ### 2. Memory Retrieval (SessionStart Hook)
 

--- a/openexp/core/config.py
+++ b/openexp/core/config.py
@@ -31,11 +31,11 @@ ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY", "").strip()
 # Ingest — observation pipeline
 OBSERVATIONS_DIR = Path(os.getenv(
     "OPENEXP_OBSERVATIONS_DIR",
-    os.path.expanduser("~/.claude-memory/observations")
+    os.path.expanduser("~/.openexp/observations")
 ))
 SESSIONS_DIR = Path(os.getenv(
     "OPENEXP_SESSIONS_DIR",
-    os.path.expanduser("~/.claude-memory/sessions")
+    os.path.expanduser("~/.openexp/sessions")
 ))
 INGEST_WATERMARK_PATH = DATA_DIR / "ingest_watermark.json"
 INGEST_BATCH_SIZE = int(os.getenv("OPENEXP_INGEST_BATCH_SIZE", "50"))

--- a/openexp/hooks/post-tool-use.sh
+++ b/openexp/hooks/post-tool-use.sh
@@ -5,7 +5,7 @@
 # for later ingestion into Qdrant via the ingest pipeline.
 set -uo pipefail
 
-OBS_DIR="$HOME/.claude-memory/observations"
+OBS_DIR="$HOME/.openexp/observations"
 mkdir -p "$OBS_DIR"
 
 # Read stdin (Claude Code passes tool call JSON)

--- a/openexp/hooks/session-start.sh
+++ b/openexp/hooks/session-start.sh
@@ -9,7 +9,7 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 OPENEXP_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
 PYTHON="$OPENEXP_DIR/.venv/bin/python3"
-SESSIONS_DIR="$HOME/.claude-memory/sessions"
+SESSIONS_DIR="$HOME/.openexp/sessions"
 TMPDIR_HOOK=$(mktemp -d)
 trap 'rm -rf "$TMPDIR_HOOK"' EXIT
 


### PR DESCRIPTION
## Summary
- Replace all `~/.claude-memory/` references with `~/.openexp/` across 8 files
- All OpenExp data now lives under a single `~/.openexp/` directory (observations, sessions, data)
- No functional change — just path consistency after rebranding from internal predecessor

## Files changed
- `openexp/core/config.py` — default paths for OBSERVATIONS_DIR and SESSIONS_DIR
- `openexp/hooks/post-tool-use.sh` — hardcoded observation write path
- `openexp/hooks/session-start.sh` — hardcoded sessions read path
- `.env.example` — commented-out default values
- `README.md` — configuration table + data flow diagram
- `docs/architecture.md` — system diagram + data persistence table
- `docs/configuration.md` — configuration table
- `docs/how-it-works.md` — observation storage description

## Test plan
- [x] `grep -r "claude-memory" .` returns zero matches
- [ ] Run `./setup.sh` on clean machine — verify `~/.openexp/` dirs created
- [ ] Start Claude Code session — verify observations written to `~/.openexp/observations/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)