### PR TITLE
Fix 10 security issues (3 HIGH, 7 MEDIUM)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,9 @@
 QDRANT_HOST=localhost
 QDRANT_PORT=6333
 OPENEXP_COLLECTION=openexp_memories
+# Qdrant API key (optional — set to enable authentication)
+# If set, setup.sh will also pass it to the Docker container as QDRANT__SERVICE__API_KEY
+# QDRANT_API_KEY=
 
 # Data directory (default: ~/.openexp/data)
 # OPENEXP_DATA_DIR=~/.openexp/data

--- a/openexp/cli.py
+++ b/openexp/cli.py
@@ -15,8 +15,16 @@ import logging
 logging.basicConfig(level=logging.WARNING)
 
 
+MAX_QUERY_LENGTH = 2000
+MAX_MEMORY_IDS = 100
+
+
 def cmd_search(args):
     """Search memories via direct Qdrant + FastEmbed."""
+    if len(args.query) > MAX_QUERY_LENGTH:
+        print(f"Error: query too long ({len(args.query)} chars, max {MAX_QUERY_LENGTH})", file=sys.stderr)
+        sys.exit(1)
+
     from .core.config import Q_CACHE_PATH
     from .core.q_value import QCache
     from .core import direct_search
@@ -77,6 +85,10 @@ def cmd_log_retrieval(args):
 
     if not memory_ids:
         return
+
+    if len(memory_ids) > MAX_MEMORY_IDS:
+        print(f"Error: too many memory IDs ({len(memory_ids)}, max {MAX_MEMORY_IDS})", file=sys.stderr)
+        sys.exit(1)
 
     log_retrieval(
         session_id=args.session_id,

--- a/openexp/core/config.py
+++ b/openexp/core/config.py
@@ -23,6 +23,7 @@ Q_CACHE_PATH = DATA_DIR / "q_cache.json"
 # Qdrant
 QDRANT_HOST = os.getenv("QDRANT_HOST", "localhost")
 QDRANT_PORT = int(os.getenv("QDRANT_PORT", "6333"))
+QDRANT_API_KEY = os.environ.get("QDRANT_API_KEY", "").strip() or None
 COLLECTION_NAME = os.getenv("OPENEXP_COLLECTION", "openexp_memories")
 
 # API keys (optional — only needed for enrichment/reflection)

--- a/openexp/core/direct_search.py
+++ b/openexp/core/direct_search.py
@@ -17,6 +17,7 @@ from qdrant_client.models import Filter, FieldCondition, MatchValue, PointStruct
 from .config import (
     QDRANT_HOST,
     QDRANT_PORT,
+    QDRANT_API_KEY,
     COLLECTION_NAME,
     EMBEDDING_MODEL,
 )
@@ -46,7 +47,7 @@ def _get_qdrant() -> QdrantClient:
     if _qdrant is None:
         with _init_lock:
             if _qdrant is None:
-                _qdrant = QdrantClient(host=QDRANT_HOST, port=QDRANT_PORT)
+                _qdrant = QdrantClient(host=QDRANT_HOST, port=QDRANT_PORT, api_key=QDRANT_API_KEY)
     return _qdrant
 
 

--- a/openexp/core/q_value.py
+++ b/openexp/core/q_value.py
@@ -6,6 +6,7 @@ get higher Q-values and are prioritized in future retrieval.
 Q-update formula: Q_new = (1 - alpha) * Q_old + alpha * reward
 Scoring formula: z_norm(sim) * w_sim + z_norm(q) * w_q
 """
+import fcntl
 import json
 import logging
 import math
@@ -113,26 +114,38 @@ class QCache:
         self._dirty.clear()
 
     def load_and_merge(self, path: Path, deltas_dir: Path):
-        """Load main cache, then merge all pending deltas."""
-        self.load(path)
-        if deltas_dir.exists():
-            merged_any = False
-            for delta_file in sorted(deltas_dir.glob("q_delta_*.json")):
-                try:
-                    delta_data = json.loads(delta_file.read_text())
-                    for mem_id, q_data in delta_data.items():
-                        existing = self.get(mem_id)
-                        if existing is None or _is_newer(q_data, existing):
-                            self._cache[mem_id] = q_data
-                            self._cache.move_to_end(mem_id)
-                            while len(self._cache) > self._max_size:
-                                self._cache.popitem(last=False)
-                    delta_file.unlink()
-                    merged_any = True
-                except (json.JSONDecodeError, OSError) as e:
-                    logger.warning("Failed to merge delta %s: %s", delta_file, e)
-            if merged_any:
-                self.save(path)
+        """Load main cache, then merge all pending deltas.
+
+        Uses fcntl.flock to prevent concurrent load_and_merge operations
+        from corrupting the cache file.
+        """
+        lock_path = path.with_suffix(".lock")
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_fd = open(lock_path, "w")
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX)
+            self.load(path)
+            if deltas_dir.exists():
+                merged_any = False
+                for delta_file in sorted(deltas_dir.glob("q_delta_*.json")):
+                    try:
+                        delta_data = json.loads(delta_file.read_text())
+                        for mem_id, q_data in delta_data.items():
+                            existing = self.get(mem_id)
+                            if existing is None or _is_newer(q_data, existing):
+                                self._cache[mem_id] = q_data
+                                self._cache.move_to_end(mem_id)
+                                while len(self._cache) > self._max_size:
+                                    self._cache.popitem(last=False)
+                        delta_file.unlink()
+                        merged_any = True
+                    except (json.JSONDecodeError, OSError) as e:
+                        logger.warning("Failed to merge delta %s: %s", delta_file, e)
+                if merged_any:
+                    self.save(path)
+        finally:
+            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            lock_fd.close()
 
 
 class QValueUpdater:

--- a/openexp/hooks/post-tool-use.sh
+++ b/openexp/hooks/post-tool-use.sh
@@ -86,7 +86,11 @@ jq -n \
   }' | if command -v flock >/dev/null 2>&1; then
     flock "$OBS_FILE.lock" tee -a "$OBS_FILE" >/dev/null
   else
+    # mkdir-based locking for macOS (no flock available)
+    LOCKDIR="$OBS_FILE.lock"
+    while ! mkdir "$LOCKDIR" 2>/dev/null; do sleep 0.01; done
     cat >> "$OBS_FILE"
+    rmdir "$LOCKDIR"
   fi
 
 echo '{"hookSpecificOutput":{"hookEventName":"PostToolUse"}}'

--- a/openexp/hooks/session-start.sh
+++ b/openexp/hooks/session-start.sh
@@ -11,6 +11,7 @@ OPENEXP_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
 PYTHON="$OPENEXP_DIR/.venv/bin/python3"
 SESSIONS_DIR="$HOME/.openexp/sessions"
 TMPDIR_HOOK=$(mktemp -d)
+chmod 700 "$TMPDIR_HOOK"
 trap 'rm -rf "$TMPDIR_HOOK"' EXIT
 
 # Read stdin (Claude Code passes session JSON)

--- a/openexp/ingest/observation.py
+++ b/openexp/ingest/observation.py
@@ -100,19 +100,38 @@ def _obs_to_payload(obs: Dict) -> Dict:
     }
 
 
-def _load_observations(obs_dir: Path) -> List[Dict]:
-    """Load all observations from JSONL files in directory."""
+MAX_FILE_SIZE = 50 * 1024 * 1024  # 50 MB
+
+
+def _load_observations(obs_dir: Path, processed_ids: set = None) -> List[Dict]:
+    """Load all observations from JSONL files in directory.
+
+    Streams line-by-line to avoid loading entire files into memory.
+    Skips files larger than MAX_FILE_SIZE and already-processed IDs early.
+    """
     all_obs = []
     for f in sorted(obs_dir.glob("observations-*.jsonl")):
-        for line in f.read_text().splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                all_obs.append(json.loads(line))
-            except json.JSONDecodeError as e:
-                logger.warning("Skipping malformed JSONL line in %s: %s", f, e)
-                continue
+        try:
+            file_size = f.stat().st_size
+        except OSError:
+            continue
+        if file_size > MAX_FILE_SIZE:
+            logger.warning("Skipping oversized observation file %s (%d bytes > %d limit)", f, file_size, MAX_FILE_SIZE)
+            continue
+        with open(f, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    obs = json.loads(line)
+                except json.JSONDecodeError as e:
+                    logger.warning("Skipping malformed JSONL line in %s: %s", f, e)
+                    continue
+                # Skip already-processed IDs early to save memory
+                if processed_ids and obs.get("id", "") in processed_ids:
+                    continue
+                all_obs.append(obs)
     return all_obs
 
 
@@ -127,7 +146,7 @@ def ingest_observations(
         return {"error": f"Observations directory not found: {obs_dir}"}
 
     watermark = IngestWatermark(INGEST_WATERMARK_PATH)
-    all_obs = _load_observations(obs_dir)
+    all_obs = _load_observations(obs_dir, processed_ids=watermark.processed_obs)
     total = len(all_obs)
 
     new_obs = []

--- a/openexp/ingest/retrieval_log.py
+++ b/openexp/ingest/retrieval_log.py
@@ -5,6 +5,7 @@ based on session outcome.
 """
 import json
 import logging
+import os
 from datetime import datetime, timezone
 from typing import List, Optional
 
@@ -13,6 +14,10 @@ from ..core.config import DATA_DIR
 logger = logging.getLogger(__name__)
 
 RETRIEVALS_PATH = DATA_DIR / "session_retrievals.jsonl"
+
+MAX_FILE_SIZE = 50 * 1024 * 1024  # 50 MB
+# Read from end of file: scan at most this many bytes for recent sessions
+_TAIL_BYTES = 512 * 1024  # 512 KB
 
 
 def log_retrieval(
@@ -35,12 +40,38 @@ def log_retrieval(
 
 
 def get_session_retrievals(session_id: str) -> List[str]:
-    """Return memory_ids retrieved for a given session."""
+    """Return memory_ids retrieved for a given session.
+
+    Reads from the end of the file since recent sessions are most likely
+    near the tail. Skips files larger than MAX_FILE_SIZE.
+    """
     if not RETRIEVALS_PATH.exists():
         return []
 
+    try:
+        file_size = RETRIEVALS_PATH.stat().st_size
+    except OSError:
+        return []
+
+    if file_size > MAX_FILE_SIZE:
+        logger.warning("Retrieval log too large, skipping: %s (%d bytes)", RETRIEVALS_PATH, file_size)
+        return []
+
     memory_ids = []
-    for line in RETRIEVALS_PATH.read_text().strip().split("\n"):
+
+    # For large files, only read the tail where recent sessions are likely found
+    if file_size > _TAIL_BYTES:
+        with open(RETRIEVALS_PATH, "rb") as f:
+            f.seek(-_TAIL_BYTES, os.SEEK_END)
+            # Discard partial first line
+            f.readline()
+            tail_data = f.read().decode("utf-8", errors="replace")
+        lines = tail_data.strip().split("\n")
+    else:
+        with open(RETRIEVALS_PATH, encoding="utf-8") as f:
+            lines = f.read().strip().split("\n")
+
+    for line in lines:
         if not line:
             continue
         try:

--- a/openexp/ingest/watermark.py
+++ b/openexp/ingest/watermark.py
@@ -34,6 +34,9 @@ class IngestWatermark:
                 logger.warning("Failed to load watermark, starting fresh: %s", e)
 
     def save(self):
+        # Auto-compact when processed_obs grows too large
+        if len(self.processed_obs) > 10000:
+            self.compact()
         self.path.parent.mkdir(parents=True, exist_ok=True)
         data = {
             "version": 1,

--- a/openexp/mcp_server.py
+++ b/openexp/mcp_server.py
@@ -1,4 +1,11 @@
-"""OpenExp MCP Server — exposes Q-learning memory to Claude Code via STDIO."""
+"""OpenExp MCP Server — exposes Q-learning memory to Claude Code via STDIO.
+
+SECURITY: This server MUST only run over STDIO transport (stdin/stdout).
+If HTTP transport is ever added, authentication (e.g., bearer tokens, mTLS)
+MUST be implemented before exposing the server on any network interface.
+Running over HTTP without authentication would allow unauthenticated access
+to the memory store and Q-value system.
+"""
 import atexit
 import json
 import sys
@@ -342,11 +349,11 @@ def main():
 
             response = {"jsonrpc": "2.0", "id": request_id, "result": result}
             print(json.dumps(response, default=str), flush=True)
-        except json.JSONDecodeError as e:
+        except json.JSONDecodeError:
             error_response = {
                 "jsonrpc": "2.0",
                 "id": None,
-                "error": {"code": -32700, "message": f"Parse error: {e}"},
+                "error": {"code": -32700, "message": "Parse error: invalid JSON"},
             }
             print(json.dumps(error_response), flush=True)
         except _ErrorResponse as e:

--- a/openexp/reward_tracker.py
+++ b/openexp/reward_tracker.py
@@ -35,8 +35,18 @@ def _append_jsonl(path: Path, data: dict):
         f.write(json.dumps(data, ensure_ascii=False) + "\n")
 
 
+MAX_FILE_SIZE = 50 * 1024 * 1024  # 50 MB
+
+
 def _load_jsonl(path: Path) -> List[dict]:
     if not path.exists():
+        return []
+    try:
+        file_size = path.stat().st_size
+    except OSError:
+        return []
+    if file_size > MAX_FILE_SIZE:
+        logger.warning("JSONL file too large, skipping: %s (%d bytes > %d limit)", path, file_size, MAX_FILE_SIZE)
         return []
     items = []
     with open(path, encoding="utf-8") as f:

--- a/setup.sh
+++ b/setup.sh
@@ -81,12 +81,14 @@ else
   if docker ps -a --format '{{.Names}}' | grep -q '^openexp-qdrant$'; then
     docker start openexp-qdrant >/dev/null
   else
-    docker run -d \
-      --name openexp-qdrant \
-      --restart unless-stopped \
-      -p 127.0.0.1:6333:6333 \
-      -v openexp_qdrant_data:/qdrant/storage \
-      qdrant/qdrant:latest >/dev/null
+    DOCKER_ARGS=(-d --name openexp-qdrant --restart unless-stopped
+      -p 127.0.0.1:6333:6333
+      --user 1000:1000
+      -v openexp_qdrant_data:/qdrant/storage)
+    if [ -n "${QDRANT_API_KEY:-}" ]; then
+      DOCKER_ARGS+=(-e "QDRANT__SERVICE__API_KEY=$QDRANT_API_KEY")
+    fi
+    docker run "${DOCKER_ARGS[@]}" qdrant/qdrant:latest >/dev/null
   fi
   # Wait for Qdrant to be ready
   echo -n "  Waiting for Qdrant..."
@@ -198,8 +200,10 @@ fi
 
 # Test Qdrant connection
 if "$OPENEXP_DIR/.venv/bin/python3" -c "
+import os
 from qdrant_client import QdrantClient
-qc = QdrantClient(host='localhost', port=6333)
+api_key = os.environ.get('QDRANT_API_KEY', '').strip() or None
+qc = QdrantClient(host='localhost', port=6333, api_key=api_key)
 info = qc.get_collection('$COLLECTION')
 print(f'  ✅ Qdrant OK (collection: $COLLECTION, vectors: {info.points_count})')
 " 2>/dev/null; then


### PR DESCRIPTION
## Summary
Security hardening based on full security review of all 27 source files.

### HIGH (3)
- **H1** — Qdrant API key auth support (`QDRANT_API_KEY` env var, passed to Docker + QdrantClient)
- **H2** — STDIO-only security note on MCP server (docs, not code change)
- **H3** — Fix JSONL append race on macOS (mkdir-based locking instead of bare `cat >>`)

### MEDIUM (7)
- **M1** — 50MB file size limits + streaming reads for all JSONL files (observation, retrieval_log, reward_tracker)
- **M2** — `fcntl.flock` on Q-cache `load_and_merge` to prevent concurrent corruption
- **M3** — Auto-compact watermark when `processed_obs > 10K` entries
- **M4** — CLI input validation (query max 2K chars, max 100 memory IDs)
- **M5** — Explicit `chmod 700` on temp directory in session-start hook
- **M6** — Sanitize JSON parse error in MCP server (no raw exception leak)
- **M7** — Run Qdrant Docker as non-root (`--user 1000:1000`)

## Test plan
- [x] All 32 existing tests pass
- [ ] Run `./setup.sh` with `QDRANT_API_KEY` set — verify auth works
- [ ] Run `./setup.sh` without `QDRANT_API_KEY` — verify backward compat
- [ ] Concurrent hook invocations produce valid JSONL on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)