### PR TITLE
Add QDRANT_API_KEY to configuration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ All settings via environment variables (`.env`):
 |----------|---------|-------------|
 | `QDRANT_HOST` | `localhost` | Qdrant server host |
 | `QDRANT_PORT` | `6333` | Qdrant server port |
+| `QDRANT_API_KEY` | *(none)* | Optional: Qdrant auth (also passed to Docker) |
 | `OPENEXP_COLLECTION` | `openexp_memories` | Qdrant collection name |
 | `OPENEXP_DATA_DIR` | `~/.openexp/data` | Q-cache, predictions, retrieval logs |
 | `OPENEXP_OBSERVATIONS_DIR` | `~/.openexp/observations` | Where hooks write observations |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,6 +11,7 @@ OpenExp uses Qdrant as its vector database. The setup script starts it via Docke
 |----------|---------|-------------|
 | `QDRANT_HOST` | `localhost` | Qdrant server hostname |
 | `QDRANT_PORT` | `6333` | Qdrant HTTP port |
+| `QDRANT_API_KEY` | *(none)* | Optional: enables Qdrant auth (also passed to Docker) |
 | `OPENEXP_COLLECTION` | `openexp_memories` | Collection name in Qdrant |
 
 ## Optional


### PR DESCRIPTION
## Summary
- Add missing `QDRANT_API_KEY` to README.md and docs/configuration.md config tables
- This env var was added in the security hardening PR but not documented in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)