### PR TITLE
feat: additive Q-learning + outcome-based rewards

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,22 @@ Session ends → productive? (commits, PRs, tests)
 Next session → better memories surface first
 ```
 
+### Outcome-Based Rewards
+
+Beyond session-level heuristics, OpenExp supports **outcome-based rewards** from real business events. When a CRM deal moves from "negotiation" to "won", the memories tagged with that client get rewarded — even if the deal took weeks to close.
+
+```
+add_memory(content="SQUAD prefers Google stack", client_id="comp-squad")
+    ↓
+... weeks of work ...
+    ↓
+CRM: SQUAD deal moves negotiation → won
+    ↓
+resolve_outcomes → finds memories tagged comp-squad → reward +0.8
+```
+
+This creates a much stronger learning signal than "did this session have git commits?"
+
 After a few sessions, OpenExp learns what context actually helps you get work done.
 
 ## Quick Start
@@ -84,6 +100,7 @@ Three hooks integrate with Claude Code automatically:
 | **SessionStart** | Session opens | Searches Qdrant for relevant memories, injects top results as context |
 | **UserPromptSubmit** | Every message | Lightweight recall — adds relevant memories to each prompt |
 | **PostToolUse** | After Write/Edit/Bash | Captures what Claude does as observations (JSONL) |
+| **SessionEnd** | Session closes | Generates summary, triggers ingest + reward (async) |
 
 The MCP server provides 8 tools for explicit memory operations (search, add, predict, reflect).
 
@@ -146,10 +163,11 @@ With 10% epsilon-greedy exploration — occasionally surfaces low-Q memories to 
 | Tool | Description |
 |------|-------------|
 | `search_memory` | Hybrid search: BM25 + vector + Q-value reranking |
-| `add_memory` | Store memory with auto-enrichment (type, tags, validity) |
+| `add_memory` | Store memory with auto-enrichment (type, tags, validity). Supports `client_id` for entity tagging |
 | `log_prediction` | Track a prediction for later outcome resolution |
 | `log_outcome` | Resolve prediction with reward → updates Q-values |
 | `get_agent_context` | Full context: memories + pending predictions |
+| `resolve_outcomes` | Run outcome resolvers (CRM stage changes → targeted rewards) |
 | `reflect` | Review recent memories for patterns |
 | `memory_stats` | Q-cache size, prediction accuracy stats |
 | `reload_q_cache` | Hot-reload Q-values from disk |
@@ -165,6 +183,9 @@ openexp ingest
 
 # Preview what would be ingested (dry run)
 openexp ingest --dry-run
+
+# Run outcome resolvers (CRM stage changes → rewards)
+openexp resolve
 
 # Show Q-cache statistics
 openexp stats
@@ -186,6 +207,8 @@ All settings via environment variables (`.env`):
 | `OPENEXP_EMBEDDING_MODEL` | `BAAI/bge-small-en-v1.5` | Embedding model (local, free) |
 | `OPENEXP_EMBEDDING_DIM` | `384` | Embedding dimensions |
 | `OPENEXP_INGEST_BATCH_SIZE` | `50` | Batch size for ingestion |
+| `OPENEXP_OUTCOME_RESOLVERS` | *(none)* | Outcome resolvers (format: `module:Class`) |
+| `OPENEXP_CRM_DIR` | *(none)* | CRM directory for CRMCSVResolver |
 | `ANTHROPIC_API_KEY` | *(none)* | Optional: enables LLM-based enrichment |
 | `OPENEXP_ENRICHMENT_MODEL` | `claude-haiku-4-5-20251001` | Model for auto-enrichment |
 
@@ -213,10 +236,16 @@ openexp/
 │   ├── watermark.py            # Idempotent ingestion tracking
 │   └── filters.py              # Filter trivial observations
 │
+├── resolvers/                  # Outcome resolvers (pluggable)
+│   └── crm_csv.py              # CRM CSV stage transition → reward events
+│
+├── outcome.py                  # Outcome resolution framework
+│
 ├── hooks/                      # Claude Code integration
 │   ├── session-start.sh        # Inject Q-ranked memories at startup
 │   ├── user-prompt-recall.sh   # Per-message context recall
-│   └── post-tool-use.sh        # Capture observations from tool calls
+│   ├── post-tool-use.sh        # Capture observations from tool calls
+│   └── session-end.sh          # Summary + ingest + reward (closes the loop)
 │
 ├── mcp_server.py               # MCP STDIO server (JSON-RPC 2.0)
 ├── reward_tracker.py           # Prediction → outcome → Q-value updates
@@ -246,6 +275,9 @@ PostToolUse hook                                  SessionStart hook
 ~/.openexp/observations/*.jsonl                Qdrant search (top 10)
       │                                          + Q-value reranking
       ↓                                                 ↑
+SessionEnd hook ──→ summary .md                         │
+      │                                                 │
+      ↓ (async)                                         │
 openexp ingest ──→ FastEmbed ──→ Qdrant ─────────────────┘
       │                            ↑
       ↓                            │

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,23 +6,23 @@
 ┌──────────────────────────────────────────────────────────────┐
 │                        Claude Code                            │
 │                                                              │
-│  ┌──────────┐    ┌───────────────┐    ┌──────────────────┐  │
-│  │ Session  │    │ User Prompt   │    │   Post Tool Use  │  │
-│  │ Start    │    │ Submit        │    │                  │  │
-│  └────┬─────┘    └──────┬────────┘    └────────┬─────────┘  │
-│       │                 │                      │             │
-└───────┼─────────────────┼──────────────────────┼─────────────┘
-        │                 │                      │
-        ▼                 ▼                      ▼
-┌──────────────┐  ┌──────────────┐      ┌──────────────┐
-│ session-     │  │ user-prompt- │      │ post-tool-   │
-│ start.sh     │  │ recall.sh    │      │ use.sh       │
-│              │  │              │      │              │
-│ Search →     │  │ Search →     │      │ → Write      │
-│ Inject ctx   │  │ Inject ctx   │      │   observation│
-└──────┬───────┘  └──────┬───────┘      └──────┬───────┘
-       │                 │                      │
-       ▼                 ▼                      ▼
+│  ┌──────────┐  ┌───────────┐  ┌────────────┐  ┌──────────┐  │
+│  │ Session  │  │ User      │  │ Post Tool  │  │ Session  │  │
+│  │ Start    │  │ Prompt    │  │ Use        │  │ End      │  │
+│  └────┬─────┘  └─────┬─────┘  └──────┬─────┘  └────┬─────┘  │
+│       │              │               │              │        │
+└───────┼──────────────┼───────────────┼──────────────┼────────┘
+        │              │               │              │
+        ▼              ▼               ▼              ▼
+┌────────────┐  ┌────────────┐  ┌────────────┐  ┌────────────┐
+│ session-   │  │ user-      │  │ post-tool- │  │ session-   │
+│ start.sh   │  │ prompt-    │  │ use.sh     │  │ end.sh     │
+│            │  │ recall.sh  │  │            │  │            │
+│ Search →   │  │ Search →   │  │ → Write    │  │ Summary →  │
+│ Inject ctx │  │ Inject ctx │  │ observation│  │ Ingest →   │
+└──────┬─────┘  └──────┬─────┘  └──────┬─────┘  │ Reward     │
+       │               │               │        └──────┬─────┘
+       ▼               ▼               ▼               ▼
 ┌──────────────────────────────┐    ┌────────────────────┐
 │        OpenExp Core          │    │  Observations Dir  │
 │                              │    │  ~/.openexp/       │
@@ -73,13 +73,21 @@ Converts raw observations (JSONL) into embedded vectors in Qdrant:
 1. **filters.py** — Drops ~60-70% of trivial observations (read-only commands, short summaries)
 2. **observation.py** — Batch embeds observations via FastEmbed, upserts to Qdrant
 3. **session_summary.py** — Parses session markdown files, creates higher-importance memories
-4. **reward.py** — Computes session productivity score, applies Q-value updates
+4. **reward.py** — Computes session productivity score, applies Q-value updates (all 3 layers)
 5. **retrieval_log.py** — Tracks which memories were recalled (for closed-loop reward)
 6. **watermark.py** — Idempotency: prevents duplicate ingestion
 
+### Outcome Resolution (`openexp/outcome.py` + `openexp/resolvers/`)
+
+Connects real-world business events to Q-value updates:
+
+1. **outcome.py** — `OutcomeEvent` dataclass, `OutcomeResolver` ABC, `resolve_outcomes()` orchestrator
+2. **resolvers/crm_csv.py** — `CRMCSVResolver`: diffs CRM CSVs, detects stage transitions, emits reward events
+3. Pipeline: resolver detects events → find tagged memories by `client_id` → apply targeted rewards
+
 ### MCP Server (`openexp/mcp_server.py`)
 
-STDIO-based MCP server exposing 8 tools. Runs as a long-lived process per Claude Code session. Initializes Q-cache on startup, saves delta on shutdown.
+STDIO-based MCP server exposing 9 tools (including `resolve_outcomes`). Runs as a long-lived process per Claude Code session. Initializes Q-cache on startup, saves delta on shutdown.
 
 ### Hooks (`openexp/hooks/`)
 
@@ -88,6 +96,7 @@ Shell scripts registered with Claude Code:
 - **session-start.sh** — Builds contextual query, searches Qdrant, formats results, logs retrieval
 - **user-prompt-recall.sh** — Per-message recall (skips trivial inputs), logs retrieval
 - **post-tool-use.sh** — Captures Write/Edit/Bash observations, skips Read/Glob/Grep
+- **session-end.sh** — Generates session summary, triggers async ingest + reward computation
 
 ## Data Persistence
 
@@ -97,6 +106,7 @@ Shell scripts registered with Claude Code:
 | Q-value cache | `~/.openexp/data/q_cache.json` | `{memory_id: {q_value, q_action, ...}}` |
 | Q-value deltas | `~/.openexp/data/deltas/` | Per-session delta files (merged on start) |
 | Predictions | `~/.openexp/data/predictions.jsonl` | Agent predictions for outcome tracking |
+| CRM snapshot | `~/.openexp/data/crm_snapshot.json` | Last-seen CRM state (for diffing) |
 | Retrieval log | `~/.openexp/data/session_retrievals.jsonl` | Which memories were recalled when |
 | Raw observations | `~/.openexp/observations/` | JSONL files per day |
 | Session summaries | `~/.openexp/sessions/` | Markdown files per session |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,6 +42,20 @@ Without `ANTHROPIC_API_KEY`, memories are stored with basic metadata. The system
 |----------|---------|-------------|
 | `OPENEXP_INGEST_BATCH_SIZE` | `50` | Observations per batch during ingest |
 
+### Outcome Resolvers
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OPENEXP_OUTCOME_RESOLVERS` | *(none)* | Comma-separated list of `module:ClassName` resolvers |
+| `OPENEXP_CRM_DIR` | *(none)* | Path to CRM directory (for `CRMCSVResolver`) |
+
+Example `.env` for CRM outcome resolution:
+```
+OPENEXP_OUTCOME_RESOLVERS=openexp.resolvers.crm_csv:CRMCSVResolver
+OPENEXP_CRM_DIR=/path/to/your/crm
+```
+
+The CRM directory should contain `relationships/deals.csv` and `relationships/leads.csv`.
+
 ## Claude Code Integration
 
 The setup script registers OpenExp in `~/.claude/settings.local.json`:
@@ -71,6 +85,9 @@ The setup script registers OpenExp in `~/.claude/settings.local.json`:
     ],
     "PostToolUse": [
       {"type": "command", "command": "/path/to/openexp/openexp/hooks/post-tool-use.sh"}
+    ],
+    "SessionEnd": [
+      {"type": "command", "command": "/path/to/openexp/openexp/hooks/session-end.sh", "timeout": 30}
     ]
   }
 }

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -42,7 +42,15 @@ When you start a new Claude Code session, the SessionStart hook:
    - **30%** Q-value (learned usefulness)
 4. Injects top results as `additionalContext` before Claude sees your prompt
 
-### 3. Q-Learning Reward Loop
+### 3. Session Summary (SessionEnd Hook)
+
+When the session ends, the SessionEnd hook:
+
+1. Generates a markdown summary from the session's observations
+2. Saves it to `~/.openexp/sessions/`
+3. Triggers async ingest + reward computation (runs in background so it doesn't block exit)
+
+### 4. Q-Learning Reward Loop
 
 This is the core innovation. After each session:
 
@@ -59,6 +67,8 @@ Over time, this creates a natural ranking where useful memories (project convent
 
 ## Reward Signals
 
+### Session-Level (Fallback)
+
 | Signal | Reward | Why |
 |--------|--------|-----|
 | `git commit` | +0.3 | Code was shipped |
@@ -70,6 +80,35 @@ Over time, this creates a natural ranking where useful memories (project convent
 | No writes + no commits | -0.1 | Unproductive session |
 | Abandoned (< 3 obs) | -0.05 | Session didn't accomplish anything |
 | Base | -0.1 | Must earn positive |
+
+### Outcome-Based (Primary)
+
+Outcome resolvers detect real business events and reward the specific memories that contributed:
+
+| CRM Transition | Event | Reward |
+|----------------|-------|--------|
+| invoiced → paid | `payment_received` | +1.0 |
+| negotiation → won | `deal_closed` | +0.8 |
+| qualified → proposal | `client_yes` | +0.6 |
+| new → qualified | `meaningful_response` | +0.4 |
+| * → lost | `deal_lost` | -0.5 |
+
+**How it works:**
+
+```
+1. Tag memories with client_id:
+   add_memory("SQUAD prefers Google", client_id="comp-squad")
+
+2. CRM changes detected (deals.csv diff):
+   SQUAD: negotiation → won
+
+3. resolve_outcomes() finds all memories with client_id="comp-squad"
+   → applies reward +0.8 to their Q-values
+
+4. Also resolves pending predictions for comp-squad
+```
+
+This creates targeted, long-horizon rewards that span weeks or months — not just single sessions.
 
 ## Three Q-Layers
 

--- a/openexp/cli.py
+++ b/openexp/cli.py
@@ -98,6 +98,41 @@ def cmd_log_retrieval(args):
     )
 
 
+def cmd_resolve(args):
+    """Run outcome resolvers to detect CRM changes and apply rewards."""
+    logging.getLogger("openexp").setLevel(logging.INFO)
+
+    from .core.config import Q_CACHE_PATH
+    from .core.q_value import QCache, QValueUpdater
+    from .ingest import _load_configured_resolvers
+    from .outcome import resolve_outcomes
+
+    resolvers = _load_configured_resolvers()
+    if not resolvers:
+        print("No outcome resolvers configured. Set OPENEXP_OUTCOME_RESOLVERS in .env")
+        sys.exit(1)
+
+    q_cache = QCache()
+    q_cache.load(Q_CACHE_PATH)
+    q_updater = QValueUpdater(cache=q_cache)
+
+    result = resolve_outcomes(
+        resolvers=resolvers,
+        q_cache=q_cache,
+        q_updater=q_updater,
+    )
+
+    if result.get("total_events", 0) > 0:
+        q_cache.save(Q_CACHE_PATH)
+
+    print(json.dumps(result, indent=2, default=str))
+
+    events = result.get("total_events", 0)
+    rewarded = result.get("memories_rewarded", 0)
+    resolved = result.get("predictions_resolved", 0)
+    print(f"\nOutcomes: {events} events, {rewarded} memories rewarded, {resolved} predictions resolved")
+
+
 def cmd_stats(args):
     """Show memory system stats."""
     from .core.config import Q_CACHE_PATH
@@ -144,6 +179,9 @@ def main():
     sp_log.add_argument("--memory-ids", required=True, help="Comma-separated memory IDs")
     sp_log.add_argument("--scores", default="", help="Comma-separated scores")
 
+    # resolve
+    sub.add_parser("resolve", help="Run outcome resolvers (CRM stage changes → rewards)")
+
     # stats
     sub.add_parser("stats", help="Show memory stats")
 
@@ -155,6 +193,8 @@ def main():
         cmd_ingest(args)
     elif args.cmd == "log-retrieval":
         cmd_log_retrieval(args)
+    elif args.cmd == "resolve":
+        cmd_resolve(args)
     elif args.cmd == "stats":
         cmd_stats(args)
     else:

--- a/openexp/core/config.py
+++ b/openexp/core/config.py
@@ -43,3 +43,9 @@ INGEST_BATCH_SIZE = int(os.getenv("OPENEXP_INGEST_BATCH_SIZE", "50"))
 
 # Enrichment model (optional — requires ANTHROPIC_API_KEY)
 ENRICHMENT_MODEL = os.getenv("OPENEXP_ENRICHMENT_MODEL", "claude-haiku-4-5-20251001")
+
+# Outcome resolvers (format: "module:ClassName,module2:ClassName2")
+OUTCOME_RESOLVERS = os.getenv("OPENEXP_OUTCOME_RESOLVERS", "").strip()
+
+# CRM directory for CRMCSVResolver (local path, not checked in)
+CRM_DIR = Path(os.getenv("OPENEXP_CRM_DIR", "")) if os.getenv("OPENEXP_CRM_DIR") else None

--- a/openexp/core/direct_search.py
+++ b/openexp/core/direct_search.py
@@ -213,11 +213,14 @@ def add_memory(
             "tags": enrichment["tags"],
             "ts_valid_start": ts_valid_start,
             "ts_valid_end": ts_valid_end,
+            **({"client_id": meta["client_id"]} if meta.get("client_id") else {}),
         },
         "importance": enrichment["weight"],
         "ts_valid_start": ts_valid_start,
         "ts_valid_end": ts_valid_end,
         "status": "active",
+        # Preserve client_id at top level for Qdrant filtering
+        **({"client_id": meta["client_id"]} if meta.get("client_id") else {}),
         "status_updated_at": datetime.now(timezone.utc).isoformat(),
     }
 

--- a/openexp/core/q_value.py
+++ b/openexp/core/q_value.py
@@ -3,7 +3,7 @@
 Q-learning on episodic memory: memories that lead to productive sessions
 get higher Q-values and are prioritized in future retrieval.
 
-Q-update formula: Q_new = (1 - alpha) * Q_old + alpha * reward
+Q-update formula: Q_new = clamp(Q_old + alpha * reward, q_floor, q_ceiling)
 Scoring formula: z_norm(sim) * w_sim + z_norm(q) * w_q
 """
 import fcntl
@@ -21,11 +21,12 @@ logger = logging.getLogger(__name__)
 
 # Q-learning defaults
 DEFAULT_Q_CONFIG = {
-    "alpha": 0.25,          # learning rate
+    "alpha": 0.25,          # learning rate (additive increment per reward)
     "gamma": 0.0,           # discount factor (single-step, no lookahead)
     "epsilon": 0.1,          # exploration probability
-    "q_init": 0.5,           # initial Q-value for new memories
+    "q_init": 0.0,           # initial Q-value for new memories (earn value from zero)
     "q_floor": -0.5,         # minimum Q-value
+    "q_ceiling": 1.0,        # maximum Q-value
     "w_sim": 0.5,            # weight for similarity in combined score
     "w_q": 0.3,              # weight for Q-value in combined score
     "w_recency": 0.1,        # weight for recency
@@ -157,7 +158,7 @@ class QValueUpdater:
 
     def __init__(self, config: Optional[Dict] = None, cache: Optional[QCache] = None):
         self.cfg = {**DEFAULT_Q_CONFIG, **(config or {})}
-        self.cache = cache or QCache()
+        self.cache = cache if cache is not None else QCache()
 
     def update(
         self,
@@ -166,20 +167,26 @@ class QValueUpdater:
         layer: str = "action",
         next_max_q: Optional[float] = None,
     ) -> Dict[str, float]:
-        """Apply Q-learning update to a specific Q-layer."""
+        """Apply additive Q-learning update to a specific Q-layer.
+
+        Formula: Q_new = clamp(Q_old + alpha * reward, q_floor, q_ceiling)
+        Each positive reward ADDS to Q-value; each negative SUBTRACTS.
+        """
         alpha = self.cfg["alpha"]
         gamma = self.cfg["gamma"]
         q_floor = self.cfg["q_floor"]
+        q_ceiling = self.cfg.get("q_ceiling", 1.0)
 
         q_data = self.cache.get(memory_id) or self._default_q_data()
         target = float(reward) + gamma * float(next_max_q or 0.0)
 
         layer_key = f"q_{layer}"
         old_q = q_data.get(layer_key, self.cfg["q_init"])
-        new_q = (1.0 - alpha) * old_q + alpha * target
+        new_q = old_q + alpha * target
 
         if q_floor is not None:
             new_q = max(q_floor, new_q)
+        new_q = min(q_ceiling, new_q)
 
         q_data[layer_key] = new_q
         q_data["q_value"] = self._combined_q(q_data)
@@ -196,17 +203,19 @@ class QValueUpdater:
         memory_id: str,
         rewards: Dict[str, float],
     ) -> Dict[str, float]:
-        """Update multiple Q-layers at once."""
+        """Update multiple Q-layers at once (additive)."""
         q_data = self.cache.get(memory_id) or self._default_q_data()
+        q_ceiling = self.cfg.get("q_ceiling", 1.0)
 
         for layer, reward in rewards.items():
             if layer in Q_LAYERS:
                 layer_key = f"q_{layer}"
                 old_q = q_data.get(layer_key, self.cfg["q_init"])
                 target = float(reward)
-                new_q = (1.0 - self.cfg["alpha"]) * old_q + self.cfg["alpha"] * target
+                new_q = old_q + self.cfg["alpha"] * target
                 if self.cfg["q_floor"] is not None:
                     new_q = max(self.cfg["q_floor"], new_q)
+                new_q = min(q_ceiling, new_q)
                 q_data[layer_key] = new_q
 
         q_data["q_value"] = self._combined_q(q_data)
@@ -257,7 +266,7 @@ class QValueScorer:
 
     def __init__(self, config: Optional[Dict] = None, cache: Optional[QCache] = None):
         self.cfg = {**DEFAULT_Q_CONFIG, **(config or {})}
-        self.cache = cache or QCache()
+        self.cache = cache if cache is not None else QCache()
 
     def rerank(
         self,

--- a/openexp/hooks/session-end.sh
+++ b/openexp/hooks/session-end.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+# OpenExp SessionEnd hook — closes the Q-learning loop.
+#
+# Two phases:
+#   1. SYNC  — Generate session summary .md from observations JSONL
+#   2. ASYNC — Trigger ingest + reward (nohup background)
+#
+# This is the critical piece: without it, observations never get ingested,
+# reward never gets computed, and Q-values stay at 0.5 forever.
+set -uo pipefail
+
+# Resolve paths relative to this script
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+OPENEXP_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+PYTHON="$OPENEXP_DIR/.venv/bin/python3"
+
+OBS_DIR="$HOME/.openexp/observations"
+SESSIONS_DIR="$HOME/.openexp/sessions"
+INGEST_LOG="$HOME/.openexp/ingest.log"
+
+# Read stdin (Claude Code passes session JSON)
+INPUT=$(cat)
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // "unknown"')
+
+# Nothing to do without a session ID
+if [ "$SESSION_ID" = "unknown" ] || [ "$SESSION_ID" = "null" ]; then
+  echo '{"hookSpecificOutput":{"hookEventName":"SessionEnd"}}'
+  exit 0
+fi
+
+SESSION_SHORT="${SESSION_ID:0:8}"
+TODAY=$(date +%Y-%m-%d)
+
+mkdir -p "$SESSIONS_DIR"
+
+# -- Phase 1: Generate session summary (synchronous, fast) --
+
+# Find observations for this session
+OBS_FILE=""
+for f in "$OBS_DIR"/observations-*.jsonl; do
+  [ -f "$f" ] || continue
+  if grep -q "\"session_id\":\"$SESSION_ID\"" "$f" 2>/dev/null || \
+     grep -q "\"session_id\": \"$SESSION_ID\"" "$f" 2>/dev/null; then
+    OBS_FILE="$f"
+    break
+  fi
+done
+
+# Also check partial session ID match (Claude Code sometimes uses short IDs)
+if [ -z "$OBS_FILE" ]; then
+  for f in "$OBS_DIR"/observations-*.jsonl; do
+    [ -f "$f" ] || continue
+    if grep -q "$SESSION_SHORT" "$f" 2>/dev/null; then
+      OBS_FILE="$f"
+      break
+    fi
+  done
+fi
+
+SUMMARY_FILE="$SESSIONS_DIR/${TODAY}-${SESSION_SHORT}.md"
+
+# Only generate if we found observations and summary doesn't exist yet
+if [ -n "$OBS_FILE" ] && [ ! -f "$SUMMARY_FILE" ]; then
+  "$PYTHON" -c "
+import json, sys
+from pathlib import Path
+from collections import OrderedDict
+
+session_id = '$SESSION_ID'
+obs_file = Path('$OBS_FILE')
+today = '$TODAY'
+
+observations = []
+for line in obs_file.read_text().splitlines():
+    if not line.strip():
+        continue
+    try:
+        obs = json.loads(line)
+    except json.JSONDecodeError:
+        continue
+    sid = obs.get('session_id', '')
+    if session_id in sid or sid.startswith(session_id[:8]):
+        observations.append(obs)
+
+if not observations:
+    sys.exit(0)
+
+# Extract unique summaries (deduplicate)
+seen = set()
+summaries = []
+for obs in observations:
+    s = obs.get('summary', '').strip()
+    if s and s not in seen:
+        seen.add(s)
+        summaries.append(s)
+
+# Extract files changed
+files = OrderedDict()
+for obs in observations:
+    fp = obs.get('context', {}).get('file_path', '')
+    tool = obs.get('tool', '')
+    if fp and tool in ('Write', 'Edit'):
+        files[Path(fp).name] = fp
+
+# Detect project
+project = observations[0].get('project', 'unknown') if observations else 'unknown'
+
+# Build markdown
+md = f'# Session Summary: {today}\n\n'
+md += f'**Session ID:** {session_id[:8]}\n'
+md += f'**Project:** {project}\n\n'
+
+md += '## What was done\n'
+for s in summaries[:30]:  # cap at 30 entries
+    md += f'- {s}\n'
+
+if files:
+    md += '\n## Files changed\n'
+    for name, full in files.items():
+        md += f'- {full}\n'
+
+Path('$SUMMARY_FILE').write_text(md)
+" 2>/dev/null
+fi
+
+# -- Phase 2: Trigger ingest + reward (async, background) --
+
+# nohup ensures ingest runs even after Claude Code exits
+(
+  cd "$OPENEXP_DIR"
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] SessionEnd: starting ingest for session $SESSION_SHORT" >> "$INGEST_LOG"
+
+  "$PYTHON" -m openexp.cli ingest --session-id "$SESSION_ID" >> "$INGEST_LOG" 2>&1
+  EXIT_CODE=$?
+
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] SessionEnd: ingest finished (exit=$EXIT_CODE)" >> "$INGEST_LOG"
+) &
+disown
+
+# Return hook output immediately (don't block session exit)
+echo '{"hookSpecificOutput":{"hookEventName":"SessionEnd"}}'

--- a/openexp/ingest/__init__.py
+++ b/openexp/ingest/__init__.py
@@ -3,10 +3,39 @@
 Public API:
     ingest_session()  — full pipeline: observations + sessions + reward
 """
+import importlib
 import logging
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 logger = logging.getLogger(__name__)
+
+
+def _load_configured_resolvers() -> List:
+    """Load outcome resolvers from OPENEXP_OUTCOME_RESOLVERS env var.
+
+    Format: "module:ClassName,module2:ClassName2"
+    Example: "openexp.resolvers.crm_csv:CRMCSVResolver"
+    """
+    from ..core.config import OUTCOME_RESOLVERS
+
+    if not OUTCOME_RESOLVERS:
+        return []
+
+    resolvers = []
+    for entry in OUTCOME_RESOLVERS.split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        try:
+            module_path, class_name = entry.rsplit(":", 1)
+            module = importlib.import_module(module_path)
+            cls = getattr(module, class_name)
+            resolvers.append(cls())
+            logger.info("Loaded outcome resolver: %s", entry)
+        except Exception as e:
+            logger.error("Failed to load resolver %s: %s", entry, e)
+
+    return resolvers
 
 
 def ingest_session(
@@ -56,5 +85,30 @@ def ingest_session(
             result["reward"]["retrieved_memories_rewarded"] = retrieved_updated
         else:
             result["reward"]["retrieved_memories_rewarded"] = 0
+
+    # Run outcome resolvers (CRM stage transitions, etc.)
+    try:
+        resolvers = _load_configured_resolvers()
+        if resolvers:
+            from ..outcome import resolve_outcomes
+            from ..core.config import Q_CACHE_PATH
+            from ..core.q_value import QCache, QValueUpdater
+
+            q_cache = QCache()
+            q_cache.load(Q_CACHE_PATH)
+            q_updater = QValueUpdater(cache=q_cache)
+
+            outcome_result = resolve_outcomes(
+                resolvers=resolvers,
+                q_cache=q_cache,
+                q_updater=q_updater,
+            )
+            result["outcomes"] = outcome_result
+
+            if outcome_result.get("total_events", 0) > 0:
+                q_cache.save(Q_CACHE_PATH)
+    except Exception as e:
+        logger.error("Outcome resolution failed: %s", e)
+        result["outcomes"] = {"error": str(e)}
 
     return result

--- a/openexp/ingest/observation.py
+++ b/openexp/ingest/observation.py
@@ -96,6 +96,7 @@ def _obs_to_payload(obs: Dict) -> Dict:
             "tool": tool,
             "tags": obs.get("tags", []),
             "file_path": obs.get("context", {}).get("file_path", ""),
+            **({"client_id": obs["client_id"]} if obs.get("client_id") else {}),
         },
     }
 

--- a/openexp/ingest/reward.py
+++ b/openexp/ingest/reward.py
@@ -63,10 +63,18 @@ def apply_session_reward(
         q_cache.load(Q_CACHE_PATH)
 
     updater = QValueUpdater(cache=q_cache)
-    updated = updater.batch_update(point_ids, reward, layer="action")
+    # Update all 3 layers: action=full, hypothesis=discounted, fit=asymmetric
+    layer_rewards = {
+        "action": reward,
+        "hypothesis": reward * 0.8,
+        "fit": reward if reward > 0 else reward * 0.5,
+    }
+    updated = {}
+    for mem_id in point_ids:
+        updated[mem_id] = updater.update_all_layers(mem_id, layer_rewards)
 
     q_cache.save(Q_CACHE_PATH)
-    logger.info("Applied session reward=%.2f to %d memories", reward, len(updated))
+    logger.info("Applied session reward=%.2f to %d memories (all layers)", reward, len(updated))
     return len(updated)
 
 

--- a/openexp/mcp_server.py
+++ b/openexp/mcp_server.py
@@ -79,6 +79,7 @@ TOOLS = [
                 "content": {"type": "string"},
                 "agent": {"type": "string", "default": "main"},
                 "type": {"type": "string", "default": "fact"},
+                "client_id": {"type": "string", "description": "Associated client/entity ID"},
             },
             "required": ["content"],
         },
@@ -154,6 +155,15 @@ TOOLS = [
         },
     },
     {
+        "name": "resolve_outcomes",
+        "description": "Run outcome resolvers to detect business events (CRM stage changes) and apply rewards to tagged memories",
+        "inputSchema": {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        },
+    },
+    {
         "name": "reload_q_cache",
         "description": "Reload Q-cache from disk. Use after manual calibration or bulk Q-value updates.",
         "inputSchema": {
@@ -222,11 +232,14 @@ def handle_request(request: dict) -> dict:
             content = args["content"]
             if len(content) > MAX_CONTENT_LENGTH:
                 return {"content": [{"type": "text", "text": json.dumps({"error": f"Content too long ({len(content)} chars, max {MAX_CONTENT_LENGTH})"})}]}
+            meta = {"source": "mcp"}
+            if args.get("client_id"):
+                meta["client_id"] = args["client_id"]
             result = direct_search.add_memory(
                 content=content,
                 agent_id=args.get("agent", "main"),
                 memory_type=args.get("type", "fact"),
-                metadata={"source": "mcp"},
+                metadata=meta,
                 q_cache=q_cache,
             )
             return {"content": [{"type": "text", "text": json.dumps(result, default=str)}]}
@@ -304,6 +317,26 @@ def handle_request(request: dict) -> dict:
                     for r in filtered[:10]
                 ],
             }
+            return {"content": [{"type": "text", "text": json.dumps(result, indent=2, default=str)}]}
+
+        elif tool_name == "resolve_outcomes":
+            from .ingest import _load_configured_resolvers
+            from .outcome import resolve_outcomes
+
+            resolvers = _load_configured_resolvers()
+            if not resolvers:
+                return {"content": [{"type": "text", "text": json.dumps({"status": "no_resolvers", "message": "No outcome resolvers configured"})}]}
+
+            result = resolve_outcomes(
+                resolvers=resolvers,
+                reward_tracker=reward_tracker,
+                q_cache=q_cache,
+                q_updater=q_updater,
+            )
+
+            if result.get("total_events", 0) > 0:
+                q_cache.save_delta(DELTAS_DIR, SESSION_ID)
+
             return {"content": [{"type": "text", "text": json.dumps(result, indent=2, default=str)}]}
 
         elif tool_name == "reload_q_cache":

--- a/openexp/outcome.py
+++ b/openexp/outcome.py
@@ -1,0 +1,176 @@
+"""Outcome-based reward resolution.
+
+Connects real-world business events (CRM stage changes, payments, etc.)
+to Q-value updates on the memories that contributed to those outcomes.
+
+This replaces the session-level "count git commits" heuristic with
+targeted, outcome-based rewards that flow back to specific memories.
+"""
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from qdrant_client.models import Filter, FieldCondition, MatchValue, ScrollRequest
+
+from .core.config import COLLECTION_NAME
+from .core.direct_search import _get_qdrant
+from .core.q_value import QCache, QValueUpdater
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class OutcomeEvent:
+    """A detected business outcome that should reward/penalize memories."""
+    entity_id: str          # client/company ID (e.g., "comp-squad")
+    event_name: str         # e.g., "deal_closed", "payment_received"
+    reward: float           # [-1.0, 1.0]
+    details: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self):
+        self.reward = max(-1.0, min(1.0, self.reward))
+
+
+class OutcomeResolver(ABC):
+    """Abstract base for outcome detection.
+
+    Subclasses scan external data sources (CRM, payment systems, etc.)
+    and return OutcomeEvents when they detect meaningful changes.
+    """
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Human-readable resolver name."""
+        ...
+
+    @abstractmethod
+    def detect_outcomes(self) -> List[OutcomeEvent]:
+        """Scan for new outcomes since last check.
+
+        Returns list of OutcomeEvents. Each event will be matched to
+        memories by entity_id and used to update Q-values.
+        """
+        ...
+
+
+def _find_memories_for_entity(entity_id: str) -> List[str]:
+    """Find all memory IDs tagged with a given entity/client ID.
+
+    Uses Qdrant scroll (no vector search needed — just payload filter).
+    """
+    qc = _get_qdrant()
+
+    qdrant_filter = Filter(
+        must=[
+            FieldCondition(
+                key="metadata.client_id",
+                match=MatchValue(value=entity_id),
+            )
+        ]
+    )
+
+    memory_ids = []
+    offset = None
+    while True:
+        results = qc.scroll(
+            collection_name=COLLECTION_NAME,
+            scroll_filter=qdrant_filter,
+            limit=100,
+            offset=offset,
+            with_payload=False,
+            with_vectors=False,
+        )
+        points, next_offset = results
+        for point in points:
+            memory_ids.append(str(point.id))
+        if next_offset is None:
+            break
+        offset = next_offset
+
+    return memory_ids
+
+
+def resolve_outcomes(
+    resolvers: List[OutcomeResolver],
+    reward_tracker: Optional[Any] = None,
+    q_cache: Optional[QCache] = None,
+    q_updater: Optional[QValueUpdater] = None,
+) -> Dict[str, Any]:
+    """Run all outcome resolvers and apply rewards.
+
+    1. Each resolver detects new OutcomeEvents
+    2. For each event: resolve matching pending predictions (if reward_tracker)
+    3. Find all memories with matching entity_id
+    4. Apply reward to found memories via Q-value updates
+
+    Returns summary of all actions taken.
+    """
+    all_events: List[OutcomeEvent] = []
+    resolver_results = {}
+
+    for resolver in resolvers:
+        try:
+            events = resolver.detect_outcomes()
+            all_events.extend(events)
+            resolver_results[resolver.name] = {
+                "events": len(events),
+                "details": [
+                    {"entity": e.entity_id, "event": e.event_name, "reward": e.reward}
+                    for e in events
+                ],
+            }
+            logger.info(
+                "Resolver %s detected %d outcomes", resolver.name, len(events)
+            )
+        except Exception as e:
+            logger.error("Resolver %s failed: %s", resolver.name, e)
+            resolver_results[resolver.name] = {"error": str(e)}
+
+    if not all_events:
+        return {
+            "total_events": 0,
+            "memories_rewarded": 0,
+            "predictions_resolved": 0,
+            "resolvers": resolver_results,
+        }
+
+    total_memories_rewarded = 0
+    total_predictions_resolved = 0
+
+    for event in all_events:
+        # 1. Resolve matching predictions
+        if reward_tracker:
+            pending = reward_tracker.get_pending_predictions(client_id=event.entity_id)
+            for pred in pending:
+                result = reward_tracker.log_outcome(
+                    prediction_id=pred["id"],
+                    outcome=f"Auto-detected: {event.event_name}",
+                    reward=event.reward,
+                    source="outcome_resolver",
+                )
+                if "error" not in result:
+                    total_predictions_resolved += 1
+
+        # 2. Find and reward tagged memories
+        memory_ids = _find_memories_for_entity(event.entity_id)
+        if memory_ids and q_updater:
+            for mem_id in memory_ids:
+                q_updater.update_all_layers(mem_id, {
+                    "action": event.reward,
+                    "hypothesis": event.reward * 0.8,
+                    "fit": event.reward if event.reward > 0 else event.reward * 0.5,
+                })
+            total_memories_rewarded += len(memory_ids)
+            logger.info(
+                "Event %s for %s: rewarded %d memories (reward=%.2f)",
+                event.event_name, event.entity_id, len(memory_ids), event.reward,
+            )
+
+    return {
+        "total_events": len(all_events),
+        "memories_rewarded": total_memories_rewarded,
+        "predictions_resolved": total_predictions_resolved,
+        "resolvers": resolver_results,
+    }

--- a/openexp/resolvers/__init__.py
+++ b/openexp/resolvers/__init__.py
@@ -1,0 +1,1 @@
+"""Outcome resolvers — detect business events and map them to rewards."""

--- a/openexp/resolvers/crm_csv.py
+++ b/openexp/resolvers/crm_csv.py
@@ -1,0 +1,241 @@
+"""CRM CSV Outcome Resolver.
+
+Reads deals.csv and leads.csv from a configurable directory,
+compares with a saved snapshot, and emits OutcomeEvents for stage transitions.
+
+Configuration:
+    Set OPENEXP_CRM_DIR environment variable to the CRM directory path.
+    The directory should contain relationships/deals.csv and relationships/leads.csv.
+"""
+import csv
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from ..core.config import DATA_DIR
+from ..outcome import OutcomeEvent, OutcomeResolver
+
+logger = logging.getLogger(__name__)
+
+# Reward values for different outcome types
+REWARD_TABLE = {
+    "payment_received": 1.0,
+    "deal_closed": 0.8,
+    "client_yes": 0.6,
+    "meaningful_response": 0.4,
+    "deal_lost": -0.5,
+}
+
+# Stage transition → (event_name, reward)
+DEAL_TRANSITIONS: Dict[Tuple[str, str], Tuple[str, float]] = {
+    ("negotiation", "won"): ("deal_closed", REWARD_TABLE["deal_closed"]),
+    ("negotiation", "closed"): ("deal_closed", REWARD_TABLE["deal_closed"]),
+    ("delivered", "invoiced"): ("deal_closed", REWARD_TABLE["deal_closed"]),
+    ("invoiced", "paid"): ("payment_received", REWARD_TABLE["payment_received"]),
+    ("*", "lost"): ("deal_lost", REWARD_TABLE["deal_lost"]),
+    ("*", "cancelled"): ("deal_lost", REWARD_TABLE["deal_lost"]),
+}
+
+LEAD_TRANSITIONS: Dict[Tuple[str, str], Tuple[str, float]] = {
+    ("new", "qualified"): ("meaningful_response", REWARD_TABLE["meaningful_response"]),
+    ("qualified", "proposal"): ("client_yes", REWARD_TABLE["client_yes"]),
+    ("qualified", "negotiation"): ("client_yes", REWARD_TABLE["client_yes"]),
+    ("proposal", "negotiation"): ("client_yes", REWARD_TABLE["client_yes"]),
+    ("negotiation", "won"): ("deal_closed", REWARD_TABLE["deal_closed"]),
+    ("negotiation", "closed"): ("deal_closed", REWARD_TABLE["deal_closed"]),
+    ("*", "lost"): ("deal_lost", REWARD_TABLE["deal_lost"]),
+    ("*", "dead"): ("deal_lost", REWARD_TABLE["deal_lost"]),
+}
+
+
+def _read_csv(path: Path) -> List[Dict]:
+    """Read a CSV file into list of dicts. Returns [] if file doesn't exist."""
+    if not path.exists():
+        return []
+    with open(path, encoding="utf-8") as f:
+        return list(csv.DictReader(f))
+
+
+def _match_transition(
+    old_stage: str,
+    new_stage: str,
+    table: Dict[Tuple[str, str], Tuple[str, float]],
+) -> Optional[Tuple[str, float]]:
+    """Match a stage transition to the reward table. Supports wildcard '*'."""
+    key = (old_stage, new_stage)
+    if key in table:
+        return table[key]
+    wildcard_key = ("*", new_stage)
+    if wildcard_key in table:
+        return table[wildcard_key]
+    return None
+
+
+def _extract_core(id_str: str) -> str:
+    """Extract core identifier by stripping type prefix.
+
+    'cli-dt-001' → 'dt-001', 'comp-squad' → 'squad', 'lead-squad-001' → 'squad-001'
+    """
+    parts = id_str.split("-", 1)
+    if len(parts) == 2 and parts[0] in ("cli", "comp", "lead", "deal"):
+        return parts[1]
+    return id_str
+
+
+def client_matches(pred_client: str, crm_client: str) -> bool:
+    """Check if two client IDs match (exact or core match).
+
+    Requires exact match or same core ID (prefix-stripped).
+    Minimum 2 chars in core to avoid false positives.
+
+    Examples:
+        comp-squad == comp-squad (exact)
+        cli-dt-001 matches comp-dt-001 (core: dt-001)
+        comp-dt matches cli-dt (core: dt)
+        comp-a-1 does NOT match cli-a-2 (cores: a-1 vs a-2)
+    """
+    if pred_client == crm_client:
+        return True
+    pred_core = _extract_core(pred_client)
+    crm_core = _extract_core(crm_client)
+    return (
+        bool(pred_core)
+        and bool(crm_core)
+        and len(pred_core) >= 2
+        and pred_core == crm_core
+    )
+
+
+class CRMCSVResolver(OutcomeResolver):
+    """Detects CRM stage transitions by diffing CSV snapshots."""
+
+    def __init__(self, crm_dir: Optional[Path] = None, snapshot_dir: Optional[Path] = None):
+        from ..core.config import CRM_DIR
+        self.crm_dir = Path(crm_dir) if crm_dir else CRM_DIR
+        self.snapshot_dir = Path(snapshot_dir) if snapshot_dir else DATA_DIR
+        if self.snapshot_dir:
+            self.snapshot_dir.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def name(self) -> str:
+        return "crm_csv"
+
+    def detect_outcomes(self) -> List[OutcomeEvent]:
+        """Scan CRM CSVs for stage transitions since last snapshot."""
+        if not self.crm_dir or not self.crm_dir.exists():
+            logger.warning("CRM directory not configured or missing: %s", self.crm_dir)
+            return []
+
+        old_snapshot = self._load_snapshot()
+        current = self._read_crm()
+        changes = self._diff(old_snapshot, current)
+        self._save_snapshot(current)
+
+        events = []
+        for change in changes:
+            entity_id = change.get("client_id") or change.get("company_id", "")
+            if entity_id:
+                events.append(OutcomeEvent(
+                    entity_id=entity_id,
+                    event_name=change["event"],
+                    reward=change["reward"],
+                    details=change,
+                ))
+
+        logger.info("CRM resolver: %d changes → %d events", len(changes), len(events))
+        return events
+
+    def _load_snapshot(self) -> Dict:
+        snapshot_file = self.snapshot_dir / "crm_snapshot.json"
+        if not snapshot_file.exists():
+            return {"deals": {}, "leads": {}}
+        try:
+            with open(snapshot_file, encoding="utf-8") as f:
+                return json.load(f)
+        except (json.JSONDecodeError, OSError) as e:
+            logger.warning("Failed to load CRM snapshot: %s", e)
+            return {"deals": {}, "leads": {}}
+
+    def _save_snapshot(self, snapshot: Dict):
+        snapshot_file = self.snapshot_dir / "crm_snapshot.json"
+        with open(snapshot_file, "w", encoding="utf-8") as f:
+            json.dump(snapshot, f, ensure_ascii=False, indent=2)
+
+    def _read_crm(self) -> Dict:
+        """Read current CRM state from CSVs."""
+        deals_path = self.crm_dir / "relationships" / "deals.csv"
+        leads_path = self.crm_dir / "relationships" / "leads.csv"
+
+        deals = {}
+        for row in _read_csv(deals_path):
+            deal_id = row.get("deal_id", "").strip()
+            if deal_id:
+                stage = row.get("stage", "").strip().lower()
+                if row.get("paid_date", "").strip() and stage != "paid":
+                    stage = "paid"
+                deals[deal_id] = {
+                    "stage": stage,
+                    "client_id": row.get("client_id", "").strip(),
+                    "name": row.get("name", "").strip(),
+                    "value": row.get("value", "").strip(),
+                }
+
+        leads = {}
+        for row in _read_csv(leads_path):
+            lead_id = row.get("lead_id", "").strip()
+            if lead_id:
+                leads[lead_id] = {
+                    "stage": row.get("stage", "").strip().lower(),
+                    "company_id": row.get("company_id", "").strip(),
+                    "estimated_value": row.get("estimated_value", "").strip(),
+                }
+
+        return {"deals": deals, "leads": leads}
+
+    def _diff(self, old: Dict, current: Dict) -> List[Dict]:
+        """Detect stage transitions between old and current CRM state."""
+        changes = []
+
+        for deal_id, deal in current.get("deals", {}).items():
+            old_deal = old.get("deals", {}).get(deal_id)
+            if old_deal is None:
+                continue
+            old_stage = old_deal.get("stage", "")
+            new_stage = deal.get("stage", "")
+            if old_stage and new_stage and old_stage != new_stage:
+                match = _match_transition(old_stage, new_stage, DEAL_TRANSITIONS)
+                if match:
+                    event, reward = match
+                    changes.append({
+                        "type": "deal",
+                        "id": deal_id,
+                        "client_id": deal.get("client_id", ""),
+                        "from_stage": old_stage,
+                        "to_stage": new_stage,
+                        "event": event,
+                        "reward": reward,
+                        "name": deal.get("name", ""),
+                    })
+
+        for lead_id, lead in current.get("leads", {}).items():
+            old_lead = old.get("leads", {}).get(lead_id)
+            if old_lead is None:
+                continue
+            old_stage = old_lead.get("stage", "")
+            new_stage = lead.get("stage", "")
+            if old_stage and new_stage and old_stage != new_stage:
+                match = _match_transition(old_stage, new_stage, LEAD_TRANSITIONS)
+                if match:
+                    event, reward = match
+                    changes.append({
+                        "type": "lead",
+                        "id": lead_id,
+                        "company_id": lead.get("company_id", ""),
+                        "from_stage": old_stage,
+                        "to_stage": new_stage,
+                        "event": event,
+                        "reward": reward,
+                    })
+
+        return changes

--- a/openexp/reward_tracker.py
+++ b/openexp/reward_tracker.py
@@ -151,9 +151,14 @@ class RewardTracker:
             self._rewrite_predictions_file()
 
         # Update Q-values (outside lock — memory_ids copied inside lock)
+        # All 3 layers get signal: action=full, hypothesis=discounted, fit=asymmetric
         updated_q = {}
         for mem_id in memory_ids:
-            updated_q[mem_id] = self.q_updater.update(mem_id, reward, layer="action")
+            updated_q[mem_id] = self.q_updater.update_all_layers(mem_id, {
+                "action": reward,
+                "hypothesis": reward * 0.8,
+                "fit": reward if reward > 0 else reward * 0.5,
+            })
 
         logger.info(
             "Outcome for %s: reward=%.2f, updated %d memories",

--- a/setup.sh
+++ b/setup.sh
@@ -179,12 +179,18 @@ SETTINGS=$(echo "$SETTINGS" | jq --arg hooks_dir "$HOOKS_DIR" '
   .hooks.PostToolUse = (.hooks.PostToolUse // []) |
   if any(.[]; .command | contains("openexp")) then . else
     . + [{"type": "command", "command": ($hooks_dir + "/post-tool-use.sh")}]
+  end |
+
+  # SessionEnd hook
+  .hooks.SessionEnd = (.hooks.SessionEnd // []) |
+  if any(.[]; .command | contains("openexp")) then . else
+    . + [{"type": "command", "command": ($hooks_dir + "/session-end.sh"), "timeout": 30}]
   end
 ')
 
 echo "$SETTINGS" | jq '.' > "$CLAUDE_SETTINGS"
 echo "  ✅ MCP server registered"
-echo "  ✅ Hooks registered (SessionStart, UserPromptSubmit, PostToolUse)"
+echo "  ✅ Hooks registered (SessionStart, UserPromptSubmit, PostToolUse, SessionEnd)"
 echo ""
 
 # --- Step 7: Verify ---

--- a/tests/test_outcome.py
+++ b/tests/test_outcome.py
@@ -1,0 +1,369 @@
+"""Tests for outcome-based reward resolution.
+
+Tests OutcomeEvent, OutcomeResolver, CRMCSVResolver, resolve_outcomes,
+and client matching logic.
+"""
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from openexp.outcome import OutcomeEvent, OutcomeResolver, resolve_outcomes, _find_memories_for_entity
+from openexp.resolvers.crm_csv import (
+    CRMCSVResolver,
+    client_matches,
+    _extract_core,
+    _match_transition,
+    DEAL_TRANSITIONS,
+    LEAD_TRANSITIONS,
+)
+
+
+# Override autouse async fixture from conftest.py
+@pytest.fixture(autouse=True)
+def cleanup_test_memories():
+    yield
+
+
+class TestOutcomeEvent:
+    def test_basic_construction(self):
+        event = OutcomeEvent(
+            entity_id="comp-squad",
+            event_name="deal_closed",
+            reward=0.8,
+        )
+        assert event.entity_id == "comp-squad"
+        assert event.event_name == "deal_closed"
+        assert event.reward == 0.8
+        assert event.details == {}
+
+    def test_reward_clamping_high(self):
+        event = OutcomeEvent(entity_id="x", event_name="y", reward=2.0)
+        assert event.reward == 1.0
+
+    def test_reward_clamping_low(self):
+        event = OutcomeEvent(entity_id="x", event_name="y", reward=-3.0)
+        assert event.reward == -1.0
+
+    def test_details_preserved(self):
+        event = OutcomeEvent(
+            entity_id="x",
+            event_name="y",
+            reward=0.5,
+            details={"from_stage": "new", "to_stage": "qualified"},
+        )
+        assert event.details["from_stage"] == "new"
+
+
+class TestClientMatching:
+    def test_exact_match(self):
+        assert client_matches("comp-squad", "comp-squad")
+
+    def test_cross_prefix_match(self):
+        assert client_matches("cli-dt-001", "comp-dt-001")
+
+    def test_short_core_match(self):
+        assert client_matches("comp-dt", "cli-dt")
+
+    def test_no_match_different_suffix(self):
+        assert not client_matches("comp-a-1", "cli-a-2")
+
+    def test_single_char_core_rejected(self):
+        assert not client_matches("comp-a", "cli-a")
+
+    def test_no_prefix_exact(self):
+        assert client_matches("squad", "squad")
+
+    def test_no_prefix_different(self):
+        assert not client_matches("squad", "other")
+
+    def test_extract_core_cli(self):
+        assert _extract_core("cli-dt-001") == "dt-001"
+
+    def test_extract_core_comp(self):
+        assert _extract_core("comp-squad") == "squad"
+
+    def test_extract_core_lead(self):
+        assert _extract_core("lead-squad-001") == "squad-001"
+
+    def test_extract_core_no_prefix(self):
+        assert _extract_core("custom-id") == "custom-id"
+
+
+class TestTransitionMatching:
+    def test_exact_deal_transition(self):
+        result = _match_transition("invoiced", "paid", DEAL_TRANSITIONS)
+        assert result is not None
+        event, reward = result
+        assert event == "payment_received"
+        assert reward == 1.0
+
+    def test_wildcard_deal_transition(self):
+        result = _match_transition("anything", "lost", DEAL_TRANSITIONS)
+        assert result is not None
+        event, reward = result
+        assert event == "deal_lost"
+        assert reward == -0.5
+
+    def test_no_match(self):
+        result = _match_transition("new", "qualified", DEAL_TRANSITIONS)
+        assert result is None
+
+    def test_lead_qualified(self):
+        result = _match_transition("new", "qualified", LEAD_TRANSITIONS)
+        assert result is not None
+        event, reward = result
+        assert event == "meaningful_response"
+        assert reward == 0.4
+
+
+class TestCRMCSVResolver:
+    def _setup_crm(self, tmp_path, deals=None, leads=None):
+        """Helper to create CRM CSV files."""
+        rel_dir = tmp_path / "relationships"
+        rel_dir.mkdir(exist_ok=True)
+
+        if deals is not None:
+            with open(rel_dir / "deals.csv", "w") as f:
+                if deals:
+                    f.write(",".join(deals[0].keys()) + "\n")
+                    for deal in deals:
+                        f.write(",".join(str(v) for v in deal.values()) + "\n")
+
+        if leads is not None:
+            with open(rel_dir / "leads.csv", "w") as f:
+                if leads:
+                    f.write(",".join(leads[0].keys()) + "\n")
+                    for lead in leads:
+                        f.write(",".join(str(v) for v in lead.values()) + "\n")
+
+    def test_no_crm_dir(self, tmp_path):
+        resolver = CRMCSVResolver(
+            crm_dir=tmp_path / "nonexistent",
+            snapshot_dir=tmp_path,
+        )
+        events = resolver.detect_outcomes()
+        assert events == []
+
+    def test_no_changes(self, tmp_path):
+        deals = [{"deal_id": "d-1", "stage": "negotiation", "client_id": "comp-x", "name": "X", "value": "100", "paid_date": ""}]
+        self._setup_crm(tmp_path, deals=deals, leads=[])
+
+        resolver = CRMCSVResolver(crm_dir=tmp_path, snapshot_dir=tmp_path)
+
+        # First run — establishes baseline
+        events1 = resolver.detect_outcomes()
+        assert events1 == []  # no old snapshot → no transitions
+
+        # Second run — no changes
+        events2 = resolver.detect_outcomes()
+        assert events2 == []
+
+    def test_deal_stage_transition(self, tmp_path):
+        # Set up initial state
+        deals_v1 = [{"deal_id": "d-1", "stage": "negotiation", "client_id": "comp-x", "name": "X", "value": "100", "paid_date": ""}]
+        self._setup_crm(tmp_path, deals=deals_v1, leads=[])
+
+        resolver = CRMCSVResolver(crm_dir=tmp_path, snapshot_dir=tmp_path)
+        resolver.detect_outcomes()  # establish baseline
+
+        # Change stage
+        deals_v2 = [{"deal_id": "d-1", "stage": "won", "client_id": "comp-x", "name": "X", "value": "100", "paid_date": ""}]
+        self._setup_crm(tmp_path, deals=deals_v2, leads=[])
+
+        events = resolver.detect_outcomes()
+        assert len(events) == 1
+        assert events[0].event_name == "deal_closed"
+        assert events[0].reward == 0.8
+        assert events[0].entity_id == "comp-x"
+
+    def test_lead_stage_transition(self, tmp_path):
+        leads_v1 = [{"lead_id": "l-1", "stage": "new", "company_id": "comp-y", "estimated_value": "500"}]
+        self._setup_crm(tmp_path, deals=[], leads=leads_v1)
+
+        resolver = CRMCSVResolver(crm_dir=tmp_path, snapshot_dir=tmp_path)
+        resolver.detect_outcomes()  # baseline
+
+        leads_v2 = [{"lead_id": "l-1", "stage": "qualified", "company_id": "comp-y", "estimated_value": "500"}]
+        self._setup_crm(tmp_path, deals=[], leads=leads_v2)
+
+        events = resolver.detect_outcomes()
+        assert len(events) == 1
+        assert events[0].event_name == "meaningful_response"
+        assert events[0].reward == 0.4
+
+    def test_paid_date_detection(self, tmp_path):
+        deals_v1 = [{"deal_id": "d-1", "stage": "invoiced", "client_id": "comp-z", "name": "Z", "value": "200", "paid_date": ""}]
+        self._setup_crm(tmp_path, deals=deals_v1, leads=[])
+
+        resolver = CRMCSVResolver(crm_dir=tmp_path, snapshot_dir=tmp_path)
+        resolver.detect_outcomes()
+
+        # paid_date now set — stage auto-detected as "paid"
+        deals_v2 = [{"deal_id": "d-1", "stage": "invoiced", "client_id": "comp-z", "name": "Z", "value": "200", "paid_date": "2026-03-22"}]
+        self._setup_crm(tmp_path, deals=deals_v2, leads=[])
+
+        events = resolver.detect_outcomes()
+        assert len(events) == 1
+        assert events[0].event_name == "payment_received"
+        assert events[0].reward == 1.0
+
+    def test_snapshot_persistence(self, tmp_path):
+        deals = [{"deal_id": "d-1", "stage": "new", "client_id": "comp-a", "name": "A", "value": "50", "paid_date": ""}]
+        self._setup_crm(tmp_path, deals=deals, leads=[])
+
+        resolver = CRMCSVResolver(crm_dir=tmp_path, snapshot_dir=tmp_path)
+        resolver.detect_outcomes()
+
+        # Verify snapshot was saved
+        snapshot_file = tmp_path / "crm_snapshot.json"
+        assert snapshot_file.exists()
+        snapshot = json.loads(snapshot_file.read_text())
+        assert "d-1" in snapshot["deals"]
+        assert snapshot["deals"]["d-1"]["stage"] == "new"
+
+
+class TestResolveOutcomes:
+    def test_no_resolvers(self):
+        result = resolve_outcomes(resolvers=[])
+        assert result["total_events"] == 0
+        assert result["memories_rewarded"] == 0
+
+    def test_with_mock_resolver(self):
+        """Mock resolver + mock Qdrant → memories get rewarded."""
+        class MockResolver(OutcomeResolver):
+            @property
+            def name(self):
+                return "mock"
+
+            def detect_outcomes(self):
+                return [
+                    OutcomeEvent(entity_id="comp-test", event_name="deal_closed", reward=0.8),
+                ]
+
+        from openexp.core.q_value import QCache, QValueUpdater
+
+        q_cache = QCache()
+        q_updater = QValueUpdater(cache=q_cache)
+
+        # Mock _find_memories_for_entity to return some IDs
+        with patch("openexp.outcome._find_memories_for_entity", return_value=["mem-1", "mem-2"]):
+            result = resolve_outcomes(
+                resolvers=[MockResolver()],
+                q_cache=q_cache,
+                q_updater=q_updater,
+            )
+
+        assert result["total_events"] == 1
+        assert result["memories_rewarded"] == 2
+
+        # Verify Q-values were updated
+        q1 = q_cache.get("mem-1")
+        assert q1 is not None
+        assert q1["q_action"] != 0.5  # updated from default
+        assert q1["q_hypothesis"] != 0.5
+        assert q1["q_fit"] != 0.5
+
+    def test_resolver_failure_handled(self):
+        """Failed resolver doesn't crash the pipeline."""
+        class FailingResolver(OutcomeResolver):
+            @property
+            def name(self):
+                return "failing"
+
+            def detect_outcomes(self):
+                raise RuntimeError("CRM is down")
+
+        result = resolve_outcomes(resolvers=[FailingResolver()])
+        assert result["total_events"] == 0
+        assert "error" in result["resolvers"]["failing"]
+
+    def test_predictions_resolved(self):
+        """Pending predictions matching entity_id get resolved."""
+        class MockResolver(OutcomeResolver):
+            @property
+            def name(self):
+                return "mock"
+
+            def detect_outcomes(self):
+                return [
+                    OutcomeEvent(entity_id="comp-test", event_name="deal_closed", reward=0.8),
+                ]
+
+        from openexp.core.q_value import QCache, QValueUpdater
+
+        q_cache = QCache()
+        q_updater = QValueUpdater(cache=q_cache)
+
+        mock_tracker = MagicMock()
+        mock_tracker.get_pending_predictions.return_value = [
+            {"id": "pred_abc123", "client_id": "comp-test", "prediction": "SQUAD will close"}
+        ]
+        mock_tracker.log_outcome.return_value = {"prediction_id": "pred_abc123", "reward": 0.8}
+
+        with patch("openexp.outcome._find_memories_for_entity", return_value=[]):
+            result = resolve_outcomes(
+                resolvers=[MockResolver()],
+                reward_tracker=mock_tracker,
+                q_cache=q_cache,
+                q_updater=q_updater,
+            )
+
+        assert result["predictions_resolved"] == 1
+        mock_tracker.log_outcome.assert_called_once()
+
+
+class TestMultiLayerReward:
+    """Test that session reward updates all 3 Q-layers."""
+
+    def test_apply_session_reward_multi_layer(self, tmp_path):
+        """apply_session_reward now updates action, hypothesis, and fit."""
+        from openexp.ingest.reward import apply_session_reward
+        from openexp.core.q_value import QCache
+
+        q_cache_path = tmp_path / "q_cache.json"
+        q_cache_path.write_text(json.dumps({
+            "mem-1": {"q_value": 0.0, "q_action": 0.0, "q_hypothesis": 0.0, "q_fit": 0.0, "q_visits": 0},
+        }))
+
+        with patch("openexp.ingest.reward.Q_CACHE_PATH", q_cache_path):
+            updated = apply_session_reward(["mem-1"], reward=0.3)
+
+        assert updated == 1
+
+        q_data = json.loads(q_cache_path.read_text())
+        entry = q_data["mem-1"]
+
+        # All layers should be updated (additive: 0.0 + 0.25 * reward)
+        assert entry["q_action"] != 0.0
+        assert entry["q_hypothesis"] != 0.0
+        assert entry["q_fit"] != 0.0
+
+        # action gets full reward, hypothesis gets discounted
+        assert entry["q_action"] > entry["q_hypothesis"]
+
+    def test_negative_reward_fit_discounted(self, tmp_path):
+        """Negative reward: fit layer gets 50% penalty (less harsh)."""
+        from openexp.ingest.reward import apply_session_reward
+
+        q_cache_path = tmp_path / "q_cache.json"
+        q_cache_path.write_text(json.dumps({
+            "mem-1": {"q_value": 0.0, "q_action": 0.0, "q_hypothesis": 0.0, "q_fit": 0.0, "q_visits": 0},
+        }))
+
+        with patch("openexp.ingest.reward.Q_CACHE_PATH", q_cache_path):
+            apply_session_reward(["mem-1"], reward=-0.4)
+
+        q_data = json.loads(q_cache_path.read_text())
+        entry = q_data["mem-1"]
+
+        # Additive: Q_new = 0.0 + 0.25 * reward
+        # action gets full -0.4, fit gets -0.2 (discounted)
+        expected_action = 0.0 + 0.25 * (-0.4)  # -0.1
+        expected_fit = 0.0 + 0.25 * (-0.2)      # -0.05
+
+        assert abs(entry["q_action"] - expected_action) < 0.01
+        assert abs(entry["q_fit"] - expected_fit) < 0.01
+        assert entry["q_fit"] > entry["q_action"]  # fit less harsh

--- a/tests/test_q_value.py
+++ b/tests/test_q_value.py
@@ -74,7 +74,7 @@ def test_q_updater_basic():
 
     result = updater.update("mem1", reward=0.8)
     first_q = result["q_value"]
-    assert first_q > 0.5  # positive reward should increase Q
+    assert first_q > 0.0  # positive reward should increase Q from 0
     assert result["q_visits"] == 1
 
     result2 = updater.update("mem1", reward=0.8)
@@ -87,7 +87,7 @@ def test_q_updater_negative_reward():
     updater = QValueUpdater(cache=cache)
 
     result = updater.update("mem1", reward=-0.5)
-    assert result["q_value"] < 0.5  # negative reward should decrease Q
+    assert result["q_value"] < 0.0  # negative reward should decrease Q below 0
 
 
 def test_q_updater_floor():
@@ -107,7 +107,7 @@ def test_q_updater_batch():
 
     results = updater.batch_update(["a", "b", "c"], reward=0.8)
     assert len(results) == 3
-    assert all(v["q_value"] > 0.5 for v in results.values())
+    assert all(v["q_value"] > 0.0 for v in results.values())
 
 
 def test_q_scorer_rerank():

--- a/tests/test_session_end.py
+++ b/tests/test_session_end.py
@@ -1,0 +1,144 @@
+"""Tests for SessionEnd hook: ingest pipeline + reward computation.
+
+Tests the Python side (ingest_session, reward, retrieval reward) with mock data.
+Does NOT test the bash script directly.
+"""
+import json
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from openexp.ingest.reward import compute_session_reward, reward_retrieved_memories
+from openexp.ingest.retrieval_log import log_retrieval, get_session_retrievals
+
+
+# Override autouse async fixture from conftest.py
+@pytest.fixture(autouse=True)
+def cleanup_test_memories():
+    yield
+
+
+class TestComputeSessionReward:
+    def test_empty_session_negative(self):
+        """Sessions with < 3 observations get extra negative reward."""
+        reward = compute_session_reward([])
+        assert reward < 0
+
+    def test_commit_positive(self):
+        """Git commits earn positive reward."""
+        obs = [
+            {"summary": "git commit -m 'fix bug'", "tool": "Bash"},
+            {"summary": "Edited main.py", "tool": "Edit"},
+            {"summary": "Read main.py", "tool": "Read"},
+        ]
+        reward = compute_session_reward(obs)
+        assert reward > 0
+
+    def test_pr_created(self):
+        """PR creation adds reward on top of commits."""
+        obs = [
+            {"summary": "git commit -m 'feat'", "tool": "Bash"},
+            {"summary": "gh pr create --title 'Add feature'", "tool": "Bash"},
+            {"summary": "Edited file.py", "tool": "Edit"},
+        ]
+        reward = compute_session_reward(obs)
+        assert reward >= 0.3  # commit + PR + write
+
+    def test_readonly_session_negative(self):
+        """Sessions with no writes and no commits are negative."""
+        obs = [
+            {"summary": "Read README.md", "tool": "Read"},
+            {"summary": "git status", "tool": "Bash"},
+            {"summary": "grep pattern", "tool": "Grep"},
+        ]
+        reward = compute_session_reward(obs)
+        assert reward < 0
+
+    def test_reward_clamped(self):
+        """Reward is clamped to [-0.5, 0.5]."""
+        # Many productive signals
+        obs = [
+            {"summary": "git commit -m 'big'", "tool": "Bash"},
+            {"summary": "gh pr create", "tool": "Bash"},
+            {"summary": "deploy prod", "tool": "Bash"},
+            {"summary": "test pass all", "tool": "Bash"},
+        ] + [{"summary": f"Edited f{i}.py", "tool": "Edit"} for i in range(20)]
+        obs += [{"type": "decision", "summary": "chose approach A", "tool": "Bash"}]
+
+        reward = compute_session_reward(obs)
+        assert -0.5 <= reward <= 0.5
+
+
+class TestRetrievalLog:
+    def test_log_and_get(self, tmp_path):
+        """Logged retrievals can be retrieved by session ID."""
+        with patch("openexp.ingest.retrieval_log.RETRIEVALS_PATH", tmp_path / "ret.jsonl"):
+            log_retrieval("sess-abc", "test query", ["mem-1", "mem-2"], [0.9, 0.8])
+            log_retrieval("sess-xyz", "other query", ["mem-3"], [0.7])
+
+            result = get_session_retrievals("sess-abc")
+            assert "mem-1" in result
+            assert "mem-2" in result
+            assert "mem-3" not in result
+
+    def test_dedup_retrievals(self, tmp_path):
+        """Duplicate memory IDs within a session are deduplicated."""
+        with patch("openexp.ingest.retrieval_log.RETRIEVALS_PATH", tmp_path / "ret.jsonl"):
+            log_retrieval("sess-abc", "q1", ["mem-1", "mem-2"], [0.9, 0.8])
+            log_retrieval("sess-abc", "q2", ["mem-2", "mem-3"], [0.85, 0.7])
+
+            result = get_session_retrievals("sess-abc")
+            assert result == ["mem-1", "mem-2", "mem-3"]
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        """Non-existent retrieval file returns empty list."""
+        with patch("openexp.ingest.retrieval_log.RETRIEVALS_PATH", tmp_path / "nope.jsonl"):
+            result = get_session_retrievals("sess-abc")
+            assert result == []
+
+
+class TestRewardRetrievedMemories:
+    def test_rewards_retrieved_memories(self, tmp_path):
+        """Retrieved memories get Q-value updates."""
+        ret_path = tmp_path / "ret.jsonl"
+        q_cache_path = tmp_path / "q_cache.json"
+
+        # Write retrieval log
+        record = {
+            "session_id": "sess-test",
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "query": "test",
+            "memory_ids": ["mem-a", "mem-b"],
+            "scores": [0.9, 0.8],
+        }
+        ret_path.write_text(json.dumps(record) + "\n")
+
+        # Write Q-cache with initial values (q_init=0.0)
+        q_cache_path.write_text(json.dumps({
+            "mem-a": {"q_value": 0.0, "q_action": 0.0, "q_hypothesis": 0.0, "q_fit": 0.0, "q_visits": 0},
+            "mem-b": {"q_value": 0.0, "q_action": 0.0, "q_hypothesis": 0.0, "q_fit": 0.0, "q_visits": 0},
+        }))
+
+        with patch("openexp.ingest.retrieval_log.RETRIEVALS_PATH", ret_path), \
+             patch("openexp.ingest.reward.Q_CACHE_PATH", q_cache_path):
+            updated = reward_retrieved_memories("sess-test", reward=0.3)
+
+        assert updated == 2
+
+        # Verify Q-values changed
+        q_data = json.loads(q_cache_path.read_text())
+        assert q_data["mem-a"]["q_action"] != 0.0  # updated by reward
+        assert q_data["mem-b"]["q_action"] != 0.0
+
+    def test_no_retrievals_no_update(self, tmp_path):
+        """If no retrievals for session, returns 0."""
+        ret_path = tmp_path / "ret.jsonl"
+        ret_path.write_text("")  # empty
+
+        with patch("openexp.ingest.retrieval_log.RETRIEVALS_PATH", ret_path):
+            updated = reward_retrieved_memories("sess-nope", reward=0.3)
+
+        assert updated == 0


### PR DESCRIPTION
## Summary

- **Q-update formula changed:** EMA → additive (`Q = clamp(Q + α*r, floor, ceiling)`)
- **q_init: 0.5 → 0.0** — memories now earn value from zero based on actual utility
- **q_ceiling: 1.0** added as upper bound
- **Outcome resolver:** CRM CSV stage transitions → memory rewards (closed-loop learning)
- **client_id tagging** on memories for per-client context
- **`resolve` CLI command** for manual outcome resolution
- **session-end hook** with retrieval reward loop (rewards memories that were actually used)

## Test plan

- [x] `pytest tests/ -v` → 73/73 pass
- [x] No private data in tracked files
- [x] `.env` not in git history
- [ ] Manual test: run session-end hook, verify Q-values update

🤖 Generated with [Claude Code](https://claude.com/claude-code)