### PR TITLE
fix(setup): setup.sh — Qdrant permissions, jq null/array handling

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -83,7 +83,8 @@ else
   else
     DOCKER_ARGS=(-d --name openexp-qdrant --restart unless-stopped
       -p 127.0.0.1:6333:6333
-      -v openexp_qdrant_data:/qdrant/storage)
+      -v openexp_qdrant_data:/qdrant/storage
+      --user 0:0)
     if [ -n "${QDRANT_API_KEY:-}" ]; then
       DOCKER_ARGS+=(-e "QDRANT__SERVICE__API_KEY=$QDRANT_API_KEY")
     fi
@@ -164,26 +165,26 @@ HOOKS_DIR="$OPENEXP_DIR/openexp/hooks"
 SETTINGS=$(echo "$SETTINGS" | jq --arg hooks_dir "$HOOKS_DIR" '
   # SessionStart hook
   .hooks.SessionStart = (.hooks.SessionStart // []) |
-  if any(.[]; .command | contains("openexp")) then . else
-    . + [{"type": "command", "command": ($hooks_dir + "/session-start.sh")}]
+  if any(.hooks.SessionStart[]; (.command // "") | contains("openexp")) then . else
+    .hooks.SessionStart += [{"type": "command", "command": ($hooks_dir + "/session-start.sh")}]
   end |
 
   # UserPromptSubmit hook
   .hooks.UserPromptSubmit = (.hooks.UserPromptSubmit // []) |
-  if any(.[]; .command | contains("openexp")) then . else
-    . + [{"type": "command", "command": ($hooks_dir + "/user-prompt-recall.sh")}]
+  if any(.hooks.UserPromptSubmit[]; (.command // "") | contains("openexp")) then . else
+    .hooks.UserPromptSubmit += [{"type": "command", "command": ($hooks_dir + "/user-prompt-recall.sh")}]
   end |
 
   # PostToolUse hook
   .hooks.PostToolUse = (.hooks.PostToolUse // []) |
-  if any(.[]; .command | contains("openexp")) then . else
-    . + [{"type": "command", "command": ($hooks_dir + "/post-tool-use.sh")}]
+  if any(.hooks.PostToolUse[]; (.command // "") | contains("openexp")) then . else
+    .hooks.PostToolUse += [{"type": "command", "command": ($hooks_dir + "/post-tool-use.sh")}]
   end |
 
   # SessionEnd hook
   .hooks.SessionEnd = (.hooks.SessionEnd // []) |
-  if any(.[]; .command | contains("openexp")) then . else
-    . + [{"type": "command", "command": ($hooks_dir + "/session-end.sh"), "timeout": 30}]
+  if any(.hooks.SessionEnd[]; (.command // "") | contains("openexp")) then . else
+    .hooks.SessionEnd += [{"type": "command", "command": ($hooks_dir + "/session-end.sh"), "timeout": 30}]
   end
 ')
 

--- a/setup.sh
+++ b/setup.sh
@@ -112,7 +112,7 @@ echo ""
 
 # --- Step 4: Create collection ---
 echo "Step 4/7: Creating Qdrant collection..."
-COLLECTION_EXISTS=$(curl -sf "http://localhost:6333/collections/$COLLECTION" 2>/dev/null | jq -r '.status // "not_found"')
+COLLECTION_EXISTS=$(curl -sf "http://localhost:6333/collections/$COLLECTION" 2>/dev/null | jq -r '.status // "not_found"' || echo "not_found")
 if [ "$COLLECTION_EXISTS" = "ok" ]; then
   echo "  ✅ Collection '$COLLECTION' already exists"
 else

--- a/setup.sh
+++ b/setup.sh
@@ -83,7 +83,6 @@ else
   else
     DOCKER_ARGS=(-d --name openexp-qdrant --restart unless-stopped
       -p 127.0.0.1:6333:6333
-      --user 1000:1000
       -v openexp_qdrant_data:/qdrant/storage)
     if [ -n "${QDRANT_API_KEY:-}" ]; then
       DOCKER_ARGS+=(-e "QDRANT__SERVICE__API_KEY=$QDRANT_API_KEY")


### PR DESCRIPTION
Cherry-picks the three fixes from @alpiua's [#9](https://github.com/anthroos/openexp/pull/9) onto current `main`. Original commits and authorship preserved.

The original PR was unmergeable as-is — its branch was based on a `main` snapshot from 2026-03-22 and merging would have reverted ~2,400 lines added since (v2 redesign, benchmark docs, roadmap, experience pack v3). All credit for the fixes goes to @alpiua; this PR just rebases them.

## Fixes

**1. Qdrant container permissions**
The `--user 1000:1000` flag denied writes to the named volume because the official Qdrant image runs as `root` (UID 0) and `/qdrant/storage` is owned by root. Replaced with explicit `--user 0:0`.

**2. Silent exit on collection check**
`COLLECTION_EXISTS=$(curl -sf … | jq -r '.status // "not_found"')` would exit with code 22 (no message) when the collection didn't yet exist and `curl` returned 404. Added `|| echo "not_found"` so the variable is always set.

**3. `jq` null + array path errors during hook registration**
- `null cannot have containment checked` — fixed with `(.command // "")` null fallback before `contains()`.
- `object and array cannot be added` — fixed by using the explicit path `any(.hooks.SessionStart[]; …)` and `+=` to append, instead of `any(.[]; …)` and `. + […]` which operated on the root object.

## Diff

`setup.sh | 22 +++++++++++-----------` — 11 insertions, 11 deletions, single file.

Closes #9

Co-authored-by: Oleksii Pylypchuk <alpi@keemail.me>