### PR TITLE
chore(github): add publish-pack issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/publish-pack.md
+++ b/.github/ISSUE_TEMPLATE/publish-pack.md
@@ -1,0 +1,47 @@
+---
+name: Publish a pack
+about: Request to add your pack to the openexp.ai catalog
+title: "Publish pack: openexp:<author>:<slug>"
+labels: pack-publish
+---
+
+<!-- Filled-in template from openexp.ai/create. You can edit anything below before submitting. -->
+
+## Pack repo
+
+Link to the public GitHub repo with your pack files:
+
+`https://github.com/<your-handle>/exp-<slug>`
+
+## Pack ID
+
+`openexp:<author>:<slug>`
+
+## Author handle
+
+`<your-handle>`
+
+## Contact
+
+`<your-email>`
+
+## License
+
+MIT (default) — change if your pack uses a different license.
+
+## Outcome
+
+- Outcome label: `closed_won` / `closed_lost` / `failed` / `abandoned`
+- Closed at: `day_+<N>` (relative to start)
+- Duration: `<N>` days, `<N>` ordered steps
+
+## Anonymization confirmation
+
+- [ ] No counterparty real names in `trajectory.anonymized.yaml` or `meta.yaml`
+- [ ] No client names, no platform names, no jurisdictions narrow enough to identify
+- [ ] Author identity (you) is public — that's intentional, like authorship on a paper
+- [ ] Read [`docs/publishing-a-pack.md`](https://github.com/anthroos/openexp/blob/main/docs/publishing-a-pack.md)
+
+## Anything else
+
+(Optional — context, why this trajectory, what's interesting about it.)


### PR DESCRIPTION
The `/create` form on openexp.ai opens GitHub issues with `?template=publish-pack.md`, but that template didn't exist in `.github/ISSUE_TEMPLATE/` (only `bug_report.md` and `feature_request.md`). Issues still got created (title/body pre-filled from URL params), but publishers had no guidance on what else to include.

Adds `publish-pack.md` with prompts for: pack repo URL, pack ID, author handle, contact, license, outcome label/duration, anonymization checklist, and pointer to `docs/publishing-a-pack.md`.